### PR TITLE
Updated yamls to add support for pods inline volumes and Clone from Pvc workflows

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-crd.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-crd.yaml
@@ -96,6 +96,16 @@ status:
 
 ---
 
+################# CSI Driver CRD ###########
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.hpe.com
+spec:
+  podInfoOnMount: true
+
+---
+
 #########################################
 ############  Snapshot CRDs  ############
 #########################################

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
@@ -274,7 +274,12 @@ rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
-
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 
 apiVersion: v1

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -6,7 +6,7 @@
 csiProvisionerImage: quay.io/k8scsi/csi-provisioner
 csiProvisionerTagv0: v0.4.2
 csiProvisionerTagv1: v1.3.0
-csiProvisionerTagv2: v1.3.0
+csiProvisionerTagv2: v1.4.0-rc1
 
 csiSnapshotterImage: quay.io/k8scsi/csi-snapshotter
 csiSnapshotterTagv0: v0.4.1

--- a/yaml/csi-driver/csi-hpe-v1.0.0.yaml
+++ b/yaml/csi-driver/csi-hpe-v1.0.0.yaml
@@ -100,6 +100,16 @@ status:
 
 ---
 
+################# CSI Driver CRD ###########
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.hpe.com
+spec:
+  podInfoOnMount: true
+
+---
+
 #########################################
 ############  Snapshot CRDs  ############
 #########################################
@@ -174,7 +184,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.3.0
+          image: quay.io/k8scsi/csi-provisioner:v1.4.0-rc1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -403,6 +413,12 @@ rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 
 ---
 

--- a/yaml/csi-driver/csi-hpe-v1.1.0.yaml
+++ b/yaml/csi-driver/csi-hpe-v1.1.0.yaml
@@ -56,6 +56,16 @@ status:
 
 ---
 
+################# CSI Driver CRD ###########
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.hpe.com
+spec:
+  podInfoOnMount: true
+
+---
+
 #########################################
 ############  Snapshot CRDs  ############
 #########################################
@@ -130,7 +140,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.3.0
+          image: quay.io/k8scsi/csi-provisioner:v1.4.0-rc1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -440,7 +450,12 @@ rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
-
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 
 #######################################


### PR DESCRIPTION
- Clone from PVC require 'v1.4.0-rc1' until we have GA build available. This is due to a bug in the external-provisioner that was fixed in the RC build.