### PR TITLE
Upgrade external-attacher from v1.0.1 to v1.1.0 for K8s 1.13 to support raw block volume feature

### DIFF
--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -20,7 +20,7 @@ nodeRegistrarTagv2: v1.1.0
 
 csiAttacherImage: quay.io/k8scsi/csi-attacher
 csiAttacherTagv0: v0.4.2
-csiAttacherTagv1: v1.0.1
+csiAttacherTagv1: v1.1.0
 csiAttacherTagv2: v1.2.0
 
 csiResizerImage: quay.io/k8scsi/csi-resizer

--- a/yaml/csi-driver/hpe-csi-k8s-1.13.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.13.yaml
@@ -225,7 +225,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.0.1
+          image: quay.io/k8scsi/csi-attacher:v1.1.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
External-attacher v1.0.1 is not constructing correct VolumeCapability when VolumeMode=Block.
Due to this, our CSI driver (ControllerPublish) will fail with appropriate error.

This is fixed v1.1.0 to send appropriate volume capability for both Filesystem mode and Block mode.