### PR TITLE
Update questions.yml

### DIFF
--- a/helm/charts/hpe-flexvolume-driver/questions.yml
+++ b/helm/charts/hpe-flexvolume-driver/questions.yml
@@ -10,6 +10,7 @@ questions:
     - "simplivity"
   default: "nimble"
   description: "HPE platform type for the deployment."
+  group: "HPE backend settings"
 - variable: backend
   label: "IP address"
   type: string


### PR DESCRIPTION
HPE platform type got dropped to the bottom. It should be grouped with 'HPE backend settings'