### PR TITLE
Support for Rancher 2.3+

### DIFF
--- a/helm/charts/hpe-flexvolume-driver/questions.yml
+++ b/helm/charts/hpe-flexvolume-driver/questions.yml
@@ -1,6 +1,20 @@
 categories:
 - storage
 questions:
+- variable: flavor
+  label: "Kubernetes flavor"
+  type: string
+  default: "rancher"
+  required: true
+  description: "Tweak Helm chart behavior."
+  group: "Rancher specific settings"
+- variable: flexVolumeExec
+  label: "FlexVolume driver directory"
+  type: string
+  default: "/var/lib/kubelet/volumeplugins"
+  required: true
+  description: "The FlexVolume driver will be installed here."
+  group: "Rancher specific settings"
 - variable: pluginType
   label: "HPE platform"
   type: enum

--- a/helm/charts/hpe-flexvolume-driver/templates/hpe-config.yaml
+++ b/helm/charts/hpe-flexvolume-driver/templates/hpe-config.yaml
@@ -44,3 +44,10 @@ data:
       "overrides":{}
     }
     {{- end }}
+
+  {{- if eq .Values.flavor "rancher"}}
+  {{ .Values.pluginType }}.json: |-
+    {
+      "dockerVolumePluginSocketPath": "/host/etc/hpe-storage/{{ .Values.pluginType }}.sock"
+    }
+  {{- end }}

--- a/helm/charts/hpe-flexvolume-driver/templates/hpe-doryd.yaml
+++ b/helm/charts/hpe-flexvolume-driver/templates/hpe-doryd.yaml
@@ -30,10 +30,14 @@ spec:
                mountPath: /etc/kubernetes
              - name: flexvolumedriver
                mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-             - name: hpeconfig
-               mountPath: /etc/hpe-storage
              - name: varlog
                mountPath: /var/log
+             - name: hpeconfig
+               mountPath: /etc/hpe-storage
+             {{- if eq .Values.flavor "rancher"}}
+             - name: hpeconfig
+               mountPath: /host/etc/hpe-storage
+             {{- end }}
           securityContext:
             privileged: true
       volumes:
@@ -42,7 +46,7 @@ spec:
              path: /etc/kubernetes
         - name: flexvolumedriver
           hostPath:
-             path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+             path: {{ .Values.flexVolumeExec }}
         - name: hpeconfig
           hostPath:
               path: /etc/hpe-storage

--- a/helm/charts/hpe-flexvolume-driver/templates/hpe-flexvolume-plugin.yaml
+++ b/helm/charts/hpe-flexvolume-driver/templates/hpe-flexvolume-plugin.yaml
@@ -28,6 +28,12 @@ spec:
             # create empty file to let plugin signal handler to perform cleanup of config/cert/dory files
             exec:
               command: [ "/bin/sh", "-c", "touch /etc/hpe-storage/remove" ]
+        {{- if eq .Values.flavor "rancher"}}
+          postStart:
+            exec:
+              command: [ "/bin/cp", "-a", "/etc/hpe-storage/{{ .Values.pluginType }}.json", 
+                       "{{ .Values.flexVolumeExec }}/hpe.com~{{ .Values.pluginType }}/{{ .Values.pluginType }}.json" ]
+        {{- end }}
         env:
         - name: LOG_LEVEL
           value: info
@@ -96,6 +102,10 @@ spec:
           mountPath: /etc/os-release
         - name: etc-hpe-storage-dir
           mountPath: /etc/hpe-storage
+        {{- if eq .Values.flavor "rancher"}}
+        - name: etc-hpe-storage-dir
+          mountPath: /host/etc/hpe-storage
+        {{- end }}
         - name: sys
           mountPath: /sys
         - name: iscsiadm
@@ -103,6 +113,11 @@ spec:
         - name: config-file
           mountPath: /etc/hpe-storage/volume-driver.json
           subPath: volume-driver.json
+        {{- if eq .Values.flavor "rancher"}}
+        - name: driver-file
+          mountPath: /etc/hpe-storage/{{ .Values.pluginType }}.json
+          subPath: {{ .Values.pluginType }}.json
+        {{- end }}
         - name: runsystemd
           mountPath: /run/systemd
         - name: libsystemd
@@ -139,7 +154,7 @@ spec:
           path: /var/lib/iscsi/
       - name: exec
         hostPath:
-          path:  {{ .Values.flexVolumeExec }}
+          path: {{ .Values.flexVolumeExec }}
       - name: runlock
         hostPath:
           path: /run/lock
@@ -174,6 +189,11 @@ spec:
       - name: config-file
         configMap:
           name: hpe-config
+      {{- if eq .Values.flavor "rancher"}}
+      - name: driver-file
+        configMap:
+          name: hpe-config
+      {{- end }}
       - name: runsystemd
         hostPath:
           path: /run/systemd


### PR DESCRIPTION
- Requires bugfix from @shivamerla to ensure we don't overwrite `nimble.json` during setup.
- Deploy/re-deploy driver tested
  - Re-deploy of driver caused problems as the cleanup processes from previous deployment removed the `hpe.com~driver` directory where I initially put the `driver.json` file. This ended up being a stale file-handle due to the internal cleanup processes we execute on shutdown. Copying the the `driver.json` file during `postStart` from the `ConfigMap` instead seemed like a good non-intrusive middle road.
- Provision/attach/mount/umount/detach/delete passed with MariaDB from the Rancher catalog