### PR TITLE
use caret range comparisons for minor version checks

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -26,9 +26,9 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: csi-provisioner
-          {{- if semverCompare "=1.12.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiProvisionerImage}}: {{- .Values.csiProvisionerTagv0}}
-          {{- else if semverCompare "=1.13.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- else if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiProvisionerImage}}: {{- .Values.csiProvisionerTagv1}}
           {{- else }}
           image: {{ .Values.csiProvisionerImage}}: {{- .Values.csiProvisionerTagv2}}
@@ -44,9 +44,9 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-attacher
-          {{- if semverCompare "=1.12.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiAttacherImage}}: {{- .Values.csiAttacherTagv0}}
-          {{- else if semverCompare "=1.13.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- else if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiAttacherImage}}: {{- .Values.csiAttacherTagv1}}
           {{- else }}
           image: {{ .Values.csiAttacherImage}}: {{- .Values.csiAttacherTagv2}}
@@ -62,9 +62,9 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-snapshotter
-          {{- if semverCompare "=1.12.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiSnapshotterImage}}: {{- .Values.csiSnapshotterTagv0}}
-          {{- else if semverCompare "=1.13.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- else if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiSnapshotterImage}}: {{- .Values.csiSnapshotterTagv1}}
           {{- else }}
           image: {{ .Values.csiSnapshotterImage}}: {{- .Values.csiSnapshotterTagv2}}
@@ -81,7 +81,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy
         {{- if semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion }}
         - name: csi-resizer
-          {{- if semverCompare "=1.14.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "^1.14.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiResizerImage}}: {{- .Values.csiResizerTagv0}}
           {{- else if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiResizerImage}}: {{- .Values.csiResizerTagv1}}

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-crd.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-crd.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare "=1.13.0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
 ---
 #############################################
 ############  CSI Node Info CRD  ############

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -25,9 +25,9 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: csi-node-driver-registrar
-          {{- if semverCompare "=1.12.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.nodeRegistrarImage}}: {{- .Values.nodeRegistrarTagv0}}
-          {{- else if semverCompare "=1.13.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- else if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.nodeRegistrarImage}}: {{- .Values.nodeRegistrarTagv1}}
           {{- else }}
           image: {{ .Values.nodeRegistrarImage}}: {{- .Values.nodeRegistrarTagv2}}
@@ -45,7 +45,7 @@ spec:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi.hpe.com/csi.sock
-            {{- if semverCompare "=1.12.0" .Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
@@ -70,7 +70,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hpe-csi-attacher-role
 rules:
-  {{- if semverCompare "=1.12.0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update"]
@@ -83,7 +83,7 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update"]
-  {{- else if semverCompare "=1.13.0" .Capabilities.KubeVersion.GitVersion }}
+  {{- else if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update"]

--- a/helm/charts/hpe-csi-driver/templates/sc.yaml
+++ b/helm/charts/hpe-csi-driver/templates/sc.yaml
@@ -26,7 +26,7 @@ parameters:
    csi.storage.k8s.io/node-stage-secret-namespace: kube-system
    csi.storage.k8s.io/node-publish-secret-name: nimble-secret
    csi.storage.k8s.io/node-publish-secret-namespace: kube-system
-   {{- if semverCompare "=1.14.0" .Capabilities.KubeVersion.GitVersion }}
+   {{- if semverCompare "^1.14.0" .Capabilities.KubeVersion.GitVersion }}
    csi.storage.k8s.io/resizer-secret-name: nimble-secret
    csi.storage.k8s.io/resizer-secret-namespace: nimble-secret
    {{- else if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}


### PR DESCRIPTION
this fixes feature enablement and image tag selection when using a patch release (e.g., 1.14.7) of k8s