### PR TITLE
add missing default value for allowVolumeExpansion

### DIFF
--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -47,6 +47,7 @@ serviceName: nimble-csp-svc
 fsType: xfs
 volumeDescription: "Volume created by the HPE CSI Driver for Kubernetes"
 accessProtocol: "iscsi"
+allowVolumeExpansion: true
 
 #service parameters
 # wait seconds for doryd/csi/csp services to start


### PR DESCRIPTION
the value is already only set if the version is >= 1.14.  a default value should be defined so the user knows it is available to set without having to read the template.