### PR TITLE
csi-helm: fix semversion checks for patch versions

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -26,7 +26,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: csi-provisioner
-          {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiProvisionerImage}}: {{- .Values.csiProvisionerTagv0}}
           {{- else }}
           image: {{ .Values.csiProvisionerImage}}: {{- .Values.csiProvisionerTagv1}}
@@ -34,9 +34,9 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            {{- if semverCompare ">= 1.13.0" .Capabilities.KubeVersion.GitVersion }}}
+            {{- if semverCompare ">= 1.13.0" .Capabilities.KubeVersion.GitVersion }}
             - "--timeout=30s"
-            {{- end }}}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -45,9 +45,9 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-attacher
-          {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiAttacherImage}}: {{- .Values.csiAttacherTagv0}}
-          {{- else if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- else if semverCompare "~1.13.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiAttacherImage}}: {{- .Values.csiAttacherTagv1}}
           {{- else }}
           image: {{ .Values.csiAttacherImage}}: {{- .Values.csiAttacherTagv2}}
@@ -63,9 +63,9 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-snapshotter
-          {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiSnapshotterImage}}: {{- .Values.csiSnapshotterTagv0}}
-          {{- else if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- else if semverCompare "~1.13.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiSnapshotterImage}}: {{- .Values.csiSnapshotterTagv1}}
           {{- else }}
           image: {{ .Values.csiSnapshotterImage}}: {{- .Values.csiSnapshotterTagv2}}
@@ -82,7 +82,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy
         {{- if semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion }}
         - name: csi-resizer
-          {{- if semverCompare "^1.14.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "~1.14.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiResizerImage}}: {{- .Values.csiResizerTagv0}}
           {{- else if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.csiResizerImage}}: {{- .Values.csiResizerTagv1}}

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -25,9 +25,9 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: csi-node-driver-registrar
-          {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- if semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.nodeRegistrarImage}}: {{- .Values.nodeRegistrarTagv0}}
-          {{- else if semverCompare "^1.13.0" .Capabilities.KubeVersion.GitVersion }}
+          {{- else if semverCompare "~1.13.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.nodeRegistrarImage}}: {{- .Values.nodeRegistrarTagv1}}
           {{- else }}
           image: {{ .Values.nodeRegistrarImage}}: {{- .Values.nodeRegistrarTagv2}}
@@ -45,7 +45,7 @@ spec:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi.hpe.com/csi.sock
-            {{- if semverCompare "^1.12.0" .Capabilities.KubeVersion.GitVersion }}
+            {{- if semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: csi-node-driver-registrar
           {{- if semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion }}
-          image: {{ .Values.nodeRegistrarImage}}: {{- .Values.nodeRegistrarTagv0}}
+          image: {{ .Values.nodeRegistrarImagev0}}: {{- .Values.nodeRegistrarTagv0}}
           {{- else if semverCompare "~1.13.0" .Capabilities.KubeVersion.GitVersion }}
           image: {{ .Values.nodeRegistrarImage}}: {{- .Values.nodeRegistrarTagv1}}
           {{- else }}

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -12,8 +12,10 @@ csiSnapshotterTagv0: v0.4.1
 csiSnapshotterTagv1: v1.2.0
 csiSnapshotterTagv2: v1.2.0
 
-nodeRegistrarImage: quay.io/k8scsi/csi-node-driver-registrar
+nodeRegistrarImagev0: quay.io/k8scsi/driver-registrar
 nodeRegistrarTagv0: v0.4.1
+
+nodeRegistarImage: quay.io/k8scsi/csi-node-driver-registrar
 nodeRegistrarTagv1: v1.1.0
 nodeRegistrarTagv2: v1.1.0
 


### PR DESCRIPTION
* Problem:
  * k8s semversion checks were using Caret range comparision, which include only major level changes.
  * but the intention was to only allow patch level range checks
* Implementation:
  * Replace caret range comparition with Tilde comparision operator for matching patch ranges
* Testing: helm install
* Review: gcostea, sbyadarhalli
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>