### PR TITLE
Mark CSP/CP/Doryd pods as system-critical for guaranteed scheduling.

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/nimble-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/nimble-csp.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         app: nimble-csp
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: nimble-csp
           image: {{ .Values.cspImage}}: {{- .Values.cspTag}}

--- a/helm/charts/hpe-flexvolume-driver/templates/hpe-doryd.yaml
+++ b/helm/charts/hpe-flexvolume-driver/templates/hpe-doryd.yaml
@@ -19,6 +19,7 @@ spec:
         daemon: hpe-dynamic-provisioner-daemon
       name: hpe-dynamic-provisioner
     spec:
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccountName: hpe-flexvolume-sa
       hostNetwork: true

--- a/helm/charts/hpe-flexvolume-driver/templates/hpecv-cp.yaml
+++ b/helm/charts/hpe-flexvolume-driver/templates/hpecv-cp.yaml
@@ -42,6 +42,7 @@ spec:
       labels:
         app: cv-cp
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: cv-cp
           image: {{ .Values.containerProviderImage}}: {{- .Values.containerProviderTag}}

--- a/yaml/csi-driver/nimble-csp.yaml
+++ b/yaml/csi-driver/nimble-csp.yaml
@@ -43,6 +43,7 @@ spec:
       labels:
         app: nimble-csp
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: nimble-csp
           image: hpestorage/nimble-csp:edge

--- a/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-aws-flexvolume-driver.yaml
+++ b/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-aws-flexvolume-driver.yaml
@@ -18,6 +18,7 @@ spec:
         daemon: hpe-dynamic-provisioner-daemon
       name: hpe-dynamic-provisioner
     spec:
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccountName: hpe-dynamic-provisioner-sa
       hostNetwork: true

--- a/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-azure-flexvolume-driver.yaml
+++ b/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-azure-flexvolume-driver.yaml
@@ -18,6 +18,7 @@ spec:
         daemon: hpe-dynamic-provisioner-daemon
       name: hpe-dynamic-provisioner
     spec:
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccountName: hpe-dynamic-provisioner-sa
       hostNetwork: true

--- a/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-cp.yaml
+++ b/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-cp.yaml
@@ -43,6 +43,7 @@ spec:
       labels:
         app: cv-cp
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: cv-cp
           image: hpestorage/cv-cp:canary

--- a/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-flexvolume-driver.yaml
+++ b/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-flexvolume-driver.yaml
@@ -18,6 +18,7 @@ spec:
         daemon: hpe-dynamic-provisioner-daemon
       name: hpe-dynamic-provisioner
     spec:
+      priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccountName: hpe-dynamic-provisioner-sa
       hostNetwork: true


### PR DESCRIPTION
Thus during node eviction or drain, they are always guaranteed to run.

Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>