### PR TITLE
Update all FlexVolume driver yaml/helm charts to point to 3.1.0 images.

### DIFF
--- a/helm/charts/hpe-flexvolume-driver/values.yaml
+++ b/helm/charts/hpe-flexvolume-driver/values.yaml
@@ -3,15 +3,15 @@
 # Declare variables to be passed into your templates.
 
 #doryd image
-dynamicProvisionerTag: canary
+dynamicProvisionerTag: v3.1.0
 dynamicProvisionerImage: hpestorage/k8s-dynamic-provisioner
 
 #flexvolume plugin image
-flexVolumeDriverTag: canary
+flexVolumeDriverTag: v3.1.0
 flexVolumeDriverImage: hpestorage/flexvolume-driver
 
 #container-provider image
-containerProviderTag: canary
+containerProviderTag: v3.1.0
 containerProviderImage: hpestorage/cv-cp
 
 #parameters

--- a/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-aws-flexvolume-driver-v3.1.0.yaml
+++ b/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-aws-flexvolume-driver-v3.1.0.yaml
@@ -25,7 +25,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         -
-          image: hpestorage/k8s-dynamic-provisioner:canary
+          image: hpestorage/k8s-dynamic-provisioner:v3.1.0
           imagePullPolicy: Always
           name: hpe-dynamic-provisioner
           volumeMounts:
@@ -121,7 +121,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: nimblevolumed
-        image: hpestorage/flexvolume-driver:canary
+        image: hpestorage/flexvolume-driver:v3.1.0
         imagePullPolicy: "Always"
         lifecycle:
           preStop:
@@ -165,12 +165,6 @@ spec:
         volumeMounts:
         - name: podsmountdir
           mountPath: /var/lib/kubelet
-          mountPropagation: Bidirectional
-        - name: ocpmountsdir
-          mountPath: /var/lib/origin
-          mountPropagation: Bidirectional
-        - name: legacymounts
-          mountPath: /opt/nimble
           mountPropagation: Bidirectional
         - name: dev
           mountPath: /dev
@@ -218,13 +212,6 @@ spec:
       - name: podsmountdir
         hostPath:
           path: /var/lib/kubelet
-      - name: ocpmountsdir
-        hostPath:
-          path: /var/lib/origin
-      # required to handle legacy mounts from NLT based plugin. Remove this for CoreOS
-      - name: legacymounts
-        hostPath:
-          path: /opt/nimble
       - name: dev
         hostPath:
           path: /dev

--- a/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-azure-flexvolume-driver-v3.1.0.yaml
+++ b/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-azure-flexvolume-driver-v3.1.0.yaml
@@ -25,7 +25,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         -
-          image: hpestorage/k8s-dynamic-provisioner:edge
+          image: hpestorage/k8s-dynamic-provisioner:v3.1.0
           imagePullPolicy: Always
           name: hpe-dynamic-provisioner
           volumeMounts:
@@ -45,7 +45,7 @@ spec:
              path: /etc/kubernetes
         - name: flexvolumedriver
           hostPath:
-             path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+             path: /etc/kubernetes/volumeplugins
         - name: hpeconfig
           hostPath:
               path: /etc/hpe-storage
@@ -121,7 +121,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: nimblevolumed
-        image: hpestorage/flexvolume-driver:edge
+        image: hpestorage/flexvolume-driver:v3.1.0
         imagePullPolicy: "Always"
         lifecycle:
           preStop:
@@ -165,12 +165,6 @@ spec:
         volumeMounts:
         - name: podsmountdir
           mountPath: /var/lib/kubelet
-          mountPropagation: Bidirectional
-        - name: ocpmountsdir
-          mountPath: /var/lib/origin
-          mountPropagation: Bidirectional
-        - name: legacymounts
-          mountPath: /opt/nimble
           mountPropagation: Bidirectional
         - name: dev
           mountPath: /dev
@@ -218,13 +212,6 @@ spec:
       - name: podsmountdir
         hostPath:
           path: /var/lib/kubelet
-      - name: ocpmountsdir
-        hostPath:
-          path: /var/lib/origin
-      # required to handle legacy mounts from NLT based plugin. Remove this for CoreOS
-      - name: legacymounts
-        hostPath:
-          path: /opt/nimble
       - name: dev
         hostPath:
           path: /dev
@@ -239,7 +226,7 @@ spec:
           path: /var/lib/iscsi
       - name: exec
         hostPath:
-          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+          path: /etc/kubernetes/volumeplugins
       - name: runlock
         hostPath:
           path: /run/lock

--- a/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-cp-v3.1.0.yaml
+++ b/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-cp-v3.1.0.yaml
@@ -46,7 +46,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: cv-cp
-          image: hpestorage/cv-cp:canary
+          image: hpestorage/cv-cp:v3.1.0
           imagePullPolicy: Always
           env:
             - name: CLOUDVOLUMES_PORTAL_SERVER

--- a/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-flexvolume-driver-v3.1.0.yaml
+++ b/yaml/flexvolume-driver/hpe-cloud-volumes/hpecv-flexvolume-driver-v3.1.0.yaml
@@ -25,7 +25,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         -
-          image: hpestorage/k8s-dynamic-provisioner:canary
+          image: hpestorage/k8s-dynamic-provisioner:v3.1.0
           imagePullPolicy: Always
           name: hpe-dynamic-provisioner
           volumeMounts:
@@ -45,7 +45,7 @@ spec:
              path: /etc/kubernetes
         - name: flexvolumedriver
           hostPath:
-             path: /etc/kubernetes/volumeplugins
+             path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
         - name: hpeconfig
           hostPath:
               path: /etc/hpe-storage
@@ -121,7 +121,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: nimblevolumed
-        image: hpestorage/flexvolume-driver:canary
+        image: hpestorage/flexvolume-driver:v3.1.0
         imagePullPolicy: "Always"
         lifecycle:
           preStop:
@@ -239,7 +239,7 @@ spec:
           path: /var/lib/iscsi
       - name: exec
         hostPath:
-          path: /etc/kubernetes/volumeplugins
+          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
       - name: runlock
         hostPath:
           path: /run/lock

--- a/yaml/flexvolume-driver/hpe-nimble-storage/hpe-flexvolume-driver-v3.1.0.yaml
+++ b/yaml/flexvolume-driver/hpe-nimble-storage/hpe-flexvolume-driver-v3.1.0.yaml
@@ -18,14 +18,13 @@ spec:
         daemon: hpe-dynamic-provisioner-daemon
       name: hpe-dynamic-provisioner
     spec:
-      priorityClassName: system-cluster-critical
       restartPolicy: Always
       serviceAccountName: hpe-dynamic-provisioner-sa
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         -
-          image: hpestorage/k8s-dynamic-provisioner:edge
+          image: hpestorage/k8s-dynamic-provisioner:v3.1.0
           imagePullPolicy: Always
           name: hpe-dynamic-provisioner
           volumeMounts:
@@ -81,6 +80,18 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["get", "list", "watch", "update", "create", "delete"]
 
 ---
 
@@ -121,7 +132,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: nimblevolumed
-        image: hpestorage/flexvolume-driver:edge
+        image: hpestorage/flexvolume-driver:v3.1.0
         imagePullPolicy: "Always"
         lifecycle:
           preStop:
@@ -131,11 +142,11 @@ spec:
         env:
         - name: LOG_LEVEL
           value: debug
-        - name: PROVIDER_SERVICE
+        - name: PROVIDER_IP
           valueFrom:
             secretKeyRef:
               name: hpe-secret
-              key: serviceName
+              key: backend
         - name: PROVIDER_USERNAME
           valueFrom:
             secretKeyRef:
@@ -146,22 +157,17 @@ spec:
             secretKeyRef:
               name: hpe-secret
               key: password
-        - name: PROVIDER_PORT
-          valueFrom:
-            secretKeyRef:
-              name: hpe-secret
-              key: servicePort
-        - name: SERVICE_NAME
-          valueFrom:
-            secretKeyRef:
-              name: hpe-secret
-              key: serviceName
         - name: PROTOCOL
-          value: iscsi
+          valueFrom:
+            secretKeyRef:
+              name: hpe-secret
+              key: protocol
+        - name: INSECURE
+          value: "false"
         - name: SCOPE
           value: global
         - name: PLUGIN_TYPE
-          value: cv
+          value: nimble
         volumeMounts:
         - name: podsmountdir
           mountPath: /var/lib/kubelet
@@ -279,6 +285,7 @@ spec:
           path: /run/systemd
       - name: libsystemd
         hostPath:
+          # need to copy node conformance service file
           path: /lib/systemd/system
       - name: usrlocal
         hostPath:


### PR DESCRIPTION
Remove OCP mount directories for EKS/AKS deployments.

Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>