### PR TITLE
csi-driver: make linux iscsi/disk/multipath tuning configurable

### DIFF
--- a/helm/charts/hpe-csi-driver/README.md
+++ b/helm/charts/hpe-csi-driver/README.md
@@ -27,6 +27,8 @@ The following table lists the configurable parameters of the HPE-CSI chart and t
 
 It's recommended to create a [values.yaml](https://github.com/hpe-storage/co-deployments/blob/master/helm/charts/hpe-csi-driver/values.yaml) file and edit it to fit the environment the chart is being deployed to. Download and edit the sample file.
 
+**Note:** HPE CSI Driver for Kubernetes automatically configures Linux iSCSI/Disk/Multipath settings based from [config.json](https://raw.githubusercontent.com/hpe-storage/co-deployments/master/helm/charts/hpe-csi-driver/files/config.json). In order to tune these values, edit the config map with `kubectl edit configmap hpe-linux-config -n kube-system` and restart node plugin using `kubectl delete pod -l app=hpe-csi-node` to apply.
+
 ### Installing the Chart
 To install the chart with the name `hpe-csi`:
 
@@ -42,13 +44,6 @@ To uninstall/delete the `hpe-csi` deployment:
 
 ```
 helm delete hpe-csi --purge
-```
-
-### Testing the Chart
-To test the chart with the name `hpe-csi`:
-
-```
-helm test hpe-csi --cleanup
 ```
 
 ### Alternative install method

--- a/helm/charts/hpe-csi-driver/README.md
+++ b/helm/charts/hpe-csi-driver/README.md
@@ -27,7 +27,7 @@ The following table lists the configurable parameters of the HPE-CSI chart and t
 
 It's recommended to create a [values.yaml](https://github.com/hpe-storage/co-deployments/blob/master/helm/charts/hpe-csi-driver/values.yaml) file and edit it to fit the environment the chart is being deployed to. Download and edit the sample file.
 
-**Note:** HPE CSI Driver for Kubernetes automatically configures Linux iSCSI/Disk/Multipath settings based from [config.json](https://raw.githubusercontent.com/hpe-storage/co-deployments/master/helm/charts/hpe-csi-driver/files/config.json). In order to tune these values, edit the config map with `kubectl edit configmap hpe-linux-config -n kube-system` and restart node plugin using `kubectl delete pod -l app=hpe-csi-node` to apply.
+**Note:** HPE CSI Driver for Kubernetes automatically configures Linux iSCSI/Multipath settings based on [config.json](https://raw.githubusercontent.com/hpe-storage/co-deployments/master/helm/charts/hpe-csi-driver/files/config.json). In order to tune these values, edit the config map with `kubectl edit configmap hpe-linux-config -n kube-system` and restart node plugin using `kubectl delete pod -l app=hpe-csi-node` to apply.
 
 ### Installing the Chart
 To install the chart with the name `hpe-csi`:

--- a/helm/charts/hpe-csi-driver/files/config.json
+++ b/helm/charts/hpe-csi-driver/files/config.json
@@ -1,54 +1,5 @@
 [
     {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Reduce latency by disabling contribution to randomness entroy pool for disk operations. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "add_random",
-        "recommendation": "0"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Request affinity of 2 is recommended to allow I/O completions on different CPU than submission CPU. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "rq_affinity",
-        "recommendation": "2"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Scheduler noop is recommended to remove I/O request sorting overhead for SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "scheduler",
-        "recommendation": "noop"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Set rotational to 0 to indicate SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "rotational",
-        "recommendation": "0"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Set minimum I/O request allocations to 512. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "nr_requests",
-        "recommendation": "512"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Set maximum I/O request size to 4MB in case of sequential I/O. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "max_sectors_kb",
-        "recommendation": "4096"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Set the maximum number of kilobytes that the operating system may read ahead during a sequential read operation. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "read_ahead_kb",
-        "recommendation": "128"
-    },
-    {
         "category": "iscsi",
         "severity": "warning",
         "description": "Manual startup of iSCSI nodes on boot. Can be set in /etc/iscsi/iscsid.conf",

--- a/helm/charts/hpe-csi-driver/files/config.json
+++ b/helm/charts/hpe-csi-driver/files/config.json
@@ -1,0 +1,177 @@
+[
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Reduce latency by disabling contribution to randomness entroy pool for disk operations. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "add_random",
+        "recommendation": "0"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Request affinity of 2 is recommended to allow I/O completions on different CPU than submission CPU. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "rq_affinity",
+        "recommendation": "2"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Scheduler noop is recommended to remove I/O request sorting overhead for SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "scheduler",
+        "recommendation": "noop"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set rotational to 0 to indicate SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "rotational",
+        "recommendation": "0"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set minimum I/O request allocations to 512. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "nr_requests",
+        "recommendation": "512"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set maximum I/O request size to 4MB in case of sequential I/O. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "max_sectors_kb",
+        "recommendation": "4096"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set the maximum number of kilobytes that the operating system may read ahead during a sequential read operation. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "read_ahead_kb",
+        "recommendation": "128"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Manual startup of iSCSI nodes on boot. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "startup",
+        "recommendation": "manual"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Replacement_timeout of 10 seconds is recommended for faster failover of I/O by multipath on path failures. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "replacement_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum login timeout of 15 seconds is recommended with iSCSI. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "login_timeout",
+        "recommendation": "15"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum timeout of 10 seconds is recommended with noop requests. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "noop_out_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum cmds_max of 512 is recommended for each session if handling multiple LUN's. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "cmds_max",
+        "recommendation": "512"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum queue_depth of 256 is recommended for each iSCSI session/path. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "queue_depth",
+        "recommendation": "256"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum number of sessions per iSCSI login is recommended to be 1 by default. If additional sessions are needed this can be set in /etc/iscsi/iscsid.conf. If NCM is running, please change min_session_per_array in /etc/ncm.conf and restart nlt service instead",
+        "parameter": "nr_sessions",
+        "recommendation": "1"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "product attribute recommended to be set to Server in /etc/multipath.conf",
+        "parameter": "product",
+        "recommendation": "\"Server\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "alua prioritizer is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "prio",
+        "recommendation": "alua"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "scsi_dh_alua device handler is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "hardware_handler",
+        "recommendation": "\"1 alua\""
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "immediate failback setting is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "failback",
+        "recommendation": "immediate"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "immediately fail i/o on transient path failures to retry on other paths, value=1. Can be set in /etc/multipath.conf",
+        "parameter": "fast_io_fail_tmo",
+        "recommendation": "5"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "queueing is recommended for 150 seconds, with no_path_retry value of 30. Can be set in /etc/multipath.conf",
+        "parameter": "no_path_retry",
+        "recommendation": "30"
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "service-time path selector is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_selector",
+        "recommendation": "\"service-time 0\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "vendor attribute recommended to be set to Nimble in /etc/multipath.conf",
+        "parameter": "vendor",
+        "recommendation": "\"Nimble\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "group paths according to ALUA path priority of active/standby. Recommended to be set to group_by_prio in /etc/multipath.conf",
+        "parameter": "path_grouping_policy",
+        "recommendation": "group_by_prio"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "tur path checker is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_checker",
+        "recommendation": "tur"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "infinite value is recommended for timeout in cases of device loss for FC. Can be set in /etc/multipath.conf",
+        "parameter": "dev_loss_tmo",
+        "recommendation": "infinity"
+    }
+]

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -101,6 +101,8 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           volumeMounts:
             - name: socket-dir

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -65,6 +65,8 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           securityContext:
             privileged: true
@@ -114,6 +116,9 @@ spec:
             - name: usrlocal
               # required to copy the conform script under host /usr/local/bin
               mountPath: /usr_local
+            - name: linux-config-file
+              mountPath: /opt/hpe-storage/nimbletune/config.json
+              subPath: config.json
       volumes:
         - name: registration-dir
           hostPath:
@@ -181,3 +186,6 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: linux-config-file
+          configMap:
+            name: hpe-linux-config

--- a/helm/charts/hpe-csi-driver/templates/hpe-linux-config.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-linux-config.yaml
@@ -1,0 +1,9 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: hpe-linux-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.json: |-
+{{ (.Files.Get "files/config.json") | indent 4 }}

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -62,6 +62,9 @@ serviceWaitTime: "10"
 # flavor
 flavor: kubernetes
 
+# log level for all csi driver components
+logLevel: info
+
 ## For creating the StorageClass automatically:
 storageClass:
   create: true

--- a/operators/hpe-csi-operator/README.md
+++ b/operators/hpe-csi-operator/README.md
@@ -31,6 +31,8 @@ Parameter list:<br/>
 4. ``values.yaml`` is the customized helm-chart configuration parameters. This is a **required parameter** and must contain a valid backend HPE storage system. All parameters that need a non-default value must be specified in this file.
 Refer to [Configuration for values.yaml.](https://github.com/hpe-storage/co-deployments/tree/master/helm/charts/hpe-csi-driver#configuration--installation) for details about various parameters.
 
+**Note:** HPE CSI Driver for Kubernetes automatically configures Linux iSCSI/Disk/Multipath settings based from [config.json](https://raw.githubusercontent.com/hpe-storage/co-deployments/master/helm/charts/hpe-csi-driver/files/config.json). In order to tune these values, edit the config map with `kubectl edit configmap hpe-linux-config -n hpe-csi` and restart node plugin using `kubectl delete pod -l app=hpe-csi-node` to apply.
+
 ### Install script steps:
 The install script will do the following:
 1. Create New Project.<br/>

--- a/operators/hpe-csi-operator/README.md
+++ b/operators/hpe-csi-operator/README.md
@@ -31,7 +31,7 @@ Parameter list:<br/>
 4. ``values.yaml`` is the customized helm-chart configuration parameters. This is a **required parameter** and must contain a valid backend HPE storage system. All parameters that need a non-default value must be specified in this file.
 Refer to [Configuration for values.yaml.](https://github.com/hpe-storage/co-deployments/tree/master/helm/charts/hpe-csi-driver#configuration--installation) for details about various parameters.
 
-**Note:** HPE CSI Driver for Kubernetes automatically configures Linux iSCSI/Disk/Multipath settings based from [config.json](https://raw.githubusercontent.com/hpe-storage/co-deployments/master/helm/charts/hpe-csi-driver/files/config.json). In order to tune these values, edit the config map with `kubectl edit configmap hpe-linux-config -n hpe-csi` and restart node plugin using `kubectl delete pod -l app=hpe-csi-node` to apply.
+**Note:** HPE CSI Driver for Kubernetes automatically configures Linux iSCSI/Multipath settings based on [config.json](https://raw.githubusercontent.com/hpe-storage/co-deployments/master/helm/charts/hpe-csi-driver/files/config.json). In order to tune these values, edit the config map with `kubectl edit configmap hpe-linux-config -n hpe-csi` and restart node plugin using `kubectl delete pod -l app=hpe-csi-node` to apply.
 
 ### Install script steps:
 The install script will do the following:

--- a/operators/hpe-csi-operator/install.sh
+++ b/operators/hpe-csi-operator/install.sh
@@ -104,4 +104,4 @@ cat deploy/rbac.yaml | sed "s|REPLACE_NAMESPACE|${NAMESPACE}|" | ${KUBECTL_NS} -
 cat deploy/operator.yaml| sed "s|REPLACE_IMAGE|${IMAGE}|" | ${KUBECTL_NS} -
 
 # 5. Use the values.yaml file to create a customized HPE CSI operator instance
-(cat deploy/cr.yaml | sed "s|REPLACE_NAMESPACE|${NAMESPACE}|"; sed 's/.*/  &/' ${VALUESFILE}) | ${KUBECTL_NS} -
+(cat deploy/cr.yaml | sed "s|REPLACE_NAMESPACE|${NAMESPACE}|"; sed 's/.*/    &/' ${VALUESFILE}) | ${KUBECTL_NS} -

--- a/yaml/csi-driver/hpe-csi-k8s-1.12.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.12.yaml
@@ -505,6 +505,9 @@ spec:
               mountPath: /lib/systemd/system
             - name: usrlocal
               mountPath: /usr_local
+            - name: linux-config-file
+              mountPath: /opt/hpe-storage/nimbletune/config.json
+              subPath: config.json
       volumes:
         - name: registration-dir
           hostPath:
@@ -571,6 +574,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: linux-config-file
+          configMap:
+            name: hpe-linux-config
 
 ---
 

--- a/yaml/csi-driver/hpe-csi-k8s-1.13.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.13.yaml
@@ -565,6 +565,9 @@ spec:
               mountPath: /lib/systemd/system
             - name: usrlocal
               mountPath: /usr_local
+            - name: linux-config-file
+              mountPath: /opt/hpe-storage/nimbletune/config.json
+              subPath: config.json
       volumes:
         - name: registration-dir
           hostPath:
@@ -630,6 +633,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: linux-config-file
+          configMap:
+            name: hpe-linux-config
 
 ---
 

--- a/yaml/csi-driver/hpe-csi-k8s-1.14.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.14.yaml
@@ -496,6 +496,9 @@ spec:
               mountPath: /lib/systemd/system
             - name: usrlocal
               mountPath: /usr_local
+            - name: linux-config-file
+              mountPath: /opt/hpe-storage/nimbletune/config.json
+              subPath: config.json
       volumes:
         - name: registration-dir
           hostPath:
@@ -561,6 +564,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: linux-config-file
+          configMap:
+            name: hpe-linux-config
 
 ---
 

--- a/yaml/csi-driver/hpe-csi-k8s-1.15.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.15.yaml
@@ -579,6 +579,9 @@ spec:
               mountPath: /lib/systemd/system
             - name: usrlocal
               mountPath: /usr_local
+            - name: linux-config-file
+              mountPath: /opt/hpe-storage/nimbletune/config.json
+              subPath: config.json
       volumes:
         - name: registration-dir
           hostPath:
@@ -644,6 +647,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: linux-config-file
+          configMap:
+            name: hpe-linux-config
 
 ---
 

--- a/yaml/csi-driver/hpe-csi-k8s-1.16.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.16.yaml
@@ -582,6 +582,9 @@ spec:
               mountPath: /lib/systemd/system
             - name: usrlocal
               mountPath: /usr_local
+            - name: linux-config-file
+              mountPath: /opt/hpe-storage/nimbletune/config.json
+              subPath: config.json
       volumes:
         - name: registration-dir
           hostPath:
@@ -647,6 +650,9 @@ spec:
         - name: sys
           hostPath:
             path: /sys
+        - name: linux-config-file
+          configMap:
+            name: hpe-linux-config
 
 ---
 

--- a/yaml/csi-driver/hpe-linux-config.yaml
+++ b/yaml/csi-driver/hpe-linux-config.yaml
@@ -8,55 +8,6 @@ data:
   config.json: |-
     [
     {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Reduce latency by disabling contribution to randomness entroy pool for disk operations. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "add_random",
-        "recommendation": "0"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Request affinity of 2 is recommended to allow I/O completions on different CPU than submission CPU. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "rq_affinity",
-        "recommendation": "2"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Scheduler noop is recommended to remove I/O request sorting overhead for SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "scheduler",
-        "recommendation": "noop"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Set rotational to 0 to indicate SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "rotational",
-        "recommendation": "0"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Set minimum I/O request allocations to 512. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "nr_requests",
-        "recommendation": "512"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Set maximum I/O request size to 4MB in case of sequential I/O. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "max_sectors_kb",
-        "recommendation": "4096"
-    },
-    {
-        "category": "disk",
-        "severity": "warning",
-        "description": "Set the maximum number of kilobytes that the operating system may read ahead during a sequential read operation. Can be tuned by UDEV using 99-nimble-tune.rules",
-        "parameter": "read_ahead_kb",
-        "recommendation": "128"
-    },
-    {
         "category": "iscsi",
         "severity": "warning",
         "description": "Manual startup of iSCSI nodes on boot. Can be set in /etc/iscsi/iscsid.conf",

--- a/yaml/csi-driver/hpe-linux-config.yaml
+++ b/yaml/csi-driver/hpe-linux-config.yaml
@@ -1,0 +1,186 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: hpe-linux-config
+  namespace: kube-system
+data:
+  config.json: |-
+    [
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Reduce latency by disabling contribution to randomness entroy pool for disk operations. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "add_random",
+        "recommendation": "0"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Request affinity of 2 is recommended to allow I/O completions on different CPU than submission CPU. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "rq_affinity",
+        "recommendation": "2"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Scheduler noop is recommended to remove I/O request sorting overhead for SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "scheduler",
+        "recommendation": "noop"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set rotational to 0 to indicate SSD disks. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "rotational",
+        "recommendation": "0"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set minimum I/O request allocations to 512. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "nr_requests",
+        "recommendation": "512"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set maximum I/O request size to 4MB in case of sequential I/O. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "max_sectors_kb",
+        "recommendation": "4096"
+    },
+    {
+        "category": "disk",
+        "severity": "warning",
+        "description": "Set the maximum number of kilobytes that the operating system may read ahead during a sequential read operation. Can be tuned by UDEV using 99-nimble-tune.rules",
+        "parameter": "read_ahead_kb",
+        "recommendation": "128"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Manual startup of iSCSI nodes on boot. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "startup",
+        "recommendation": "manual"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Replacement_timeout of 10 seconds is recommended for faster failover of I/O by multipath on path failures. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "replacement_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum login timeout of 15 seconds is recommended with iSCSI. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "login_timeout",
+        "recommendation": "15"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum timeout of 10 seconds is recommended with noop requests. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "noop_out_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum cmds_max of 512 is recommended for each session if handling multiple LUN's. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "cmds_max",
+        "recommendation": "512"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum queue_depth of 256 is recommended for each iSCSI session/path. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "queue_depth",
+        "recommendation": "256"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum number of sessions per iSCSI login is recommended to be 1 by default. If additional sessions are needed this can be set in /etc/iscsi/iscsid.conf. If NCM is running, please change min_session_per_array in /etc/ncm.conf and restart nlt service instead",
+        "parameter": "nr_sessions",
+        "recommendation": "1"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "product attribute recommended to be set to Server in /etc/multipath.conf",
+        "parameter": "product",
+        "recommendation": "\"Server\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "alua prioritizer is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "prio",
+        "recommendation": "alua"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "scsi_dh_alua device handler is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "hardware_handler",
+        "recommendation": "\"1 alua\""
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "immediate failback setting is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "failback",
+        "recommendation": "immediate"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "immediately fail i/o on transient path failures to retry on other paths, value=1. Can be set in /etc/multipath.conf",
+        "parameter": "fast_io_fail_tmo",
+        "recommendation": "5"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "queueing is recommended for 150 seconds, with no_path_retry value of 30. Can be set in /etc/multipath.conf",
+        "parameter": "no_path_retry",
+        "recommendation": "30"
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "service-time path selector is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_selector",
+        "recommendation": "\"service-time 0\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "vendor attribute recommended to be set to Nimble in /etc/multipath.conf",
+        "parameter": "vendor",
+        "recommendation": "\"Nimble\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "group paths according to ALUA path priority of active/standby. Recommended to be set to group_by_prio in /etc/multipath.conf",
+        "parameter": "path_grouping_policy",
+        "recommendation": "group_by_prio"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "tur path checker is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_checker",
+        "recommendation": "tur"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "infinite value is recommended for timeout in cases of device loss for FC. Can be set in /etc/multipath.conf",
+        "parameter": "dev_loss_tmo",
+        "recommendation": "infinity"
+    }
+    ]
+


### PR DESCRIPTION
* Problem:
  * currently our drivers are applying changes from fixed template and not user
  * configurable. settings like queue_depth, max_sectors_kb should be configurable
  * based on workloads.
* Implementation:
  * Added config-map called hpe-linux-config with all template settings we have
  * User can edit as required and re-deploy node plugin to apply those changes
  * This will be first stage of changes for csi1.0 and later can be modified to control
  * 3par multipath settings etc.
* Testing: deployed using helm/yaml and verified settings are applied.
* Review: gcostea, rkumar, sbyadarahalli
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>