### PR TITLE
Implement suggestions by Google on HPE CSI driver.

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-crd.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-crd.yaml
@@ -1,50 +1,3 @@
-{{- if or (semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion) (semverCompare "~1.13.0" .Capabilities.KubeVersion.GitVersion) }}
----
-#############################################
-############  CSI Node Info CRD  ############
-#############################################
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  name: csinodeinfos.csi.storage.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
-spec:
-  group: csi.storage.k8s.io
-  names:
-    kind: CSINodeInfo
-    plural: csinodeinfos
-  scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        csiDrivers:
-          description: List of CSI drivers running on the node and their properties.
-          items:
-            properties:
-              driver:
-                description: The CSI driver that this object refers to.
-                type: string
-              nodeID:
-                description: The node from the driver point of view.
-                type: string
-              topologyKeys:
-                description: List of keys supported by the driver.
-                items:
-                  type: string
-                type: array
-          type: array
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-{{- end }}
-
 {{- if semverCompare ">=1.12.0" .Capabilities.KubeVersion.GitVersion }}
 ---
 
@@ -105,44 +58,7 @@ status:
   storedVersions: []
 {{- end }}
 
-{{- if semverCompare "~1.13.0" .Capabilities.KubeVersion.GitVersion }}
----
-
-#############################################
-############  CSI Driver Info CRD  ##########
-#############################################
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: csidrivers.csi.storage.k8s.io
-  labels:
-    addonmanager.kubernetes.io/mode: Reconcile
-  annotations:
-    "helm.sh/hook": crd-install
-spec:
-  group: csi.storage.k8s.io
-  names:
-    kind: CSIDriver
-    plural: csidrivers
-  scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: Specification of the CSI Driver.
-          properties:
-            attachRequired:
-              description: Indicates this CSI volume driver requires an attach operation,
-                and that Kubernetes should call attach and wait for any attach operation
-                to complete before proceeding to mount.
-              type: boolean
-            podInfoOnMountVersion:
-              description: Indicates this CSI volume driver requires additional pod
-                information (like podName, podUID, etc.) during mount operations.
-              type: string
-  version: v1alpha1
-{{- else if semverCompare "^1.14.0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion }}
 ---
 
 ################# CSI Driver CRD ###########

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
@@ -315,33 +315,6 @@ metadata:
 
 ---
 
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-role
-  namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-binding
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: hpe-csi-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/yaml/csi-driver/hpe-csi-k8s-1.13.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.13.yaml
@@ -6,50 +6,6 @@
 ---
 
 #############################################
-############  CSI Node Info CRD  ############
-#############################################
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  name: csinodeinfos.csi.storage.k8s.io
-spec:
-  group: csi.storage.k8s.io
-  names:
-    kind: CSINodeInfo
-    plural: csinodeinfos
-  scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        csiDrivers:
-          description: List of CSI drivers running on the node and their properties.
-          items:
-            properties:
-              driver:
-                description: The CSI driver that this object refers to.
-                type: string
-              nodeID:
-                description: The node from the driver point of view.
-                type: string
-              topologyKeys:
-                description: List of keys supported by the driver.
-                items:
-                  type: string
-                type: array
-          type: array
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-
-#############################################
 ############  HPE Node Info CRD  ############
 #############################################
 
@@ -103,41 +59,6 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
----
-
-#############################################
-############  CSI Driver Info CRD  ##########
-#############################################
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: csidrivers.csi.storage.k8s.io
-  labels:
-    addonmanager.kubernetes.io/mode: Reconcile
-spec:
-  group: csi.storage.k8s.io
-  names:
-    kind: CSIDriver
-    plural: csidrivers
-  scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: Specification of the CSI Driver.
-          properties:
-            attachRequired:
-              description: Indicates this CSI volume driver requires an attach operation,
-                and that Kubernetes should call attach and wait for any attach operation
-                to complete before proceeding to mount.
-              type: boolean
-            podInfoOnMountVersion:
-              description: Indicates this CSI volume driver requires additional pod
-                information (like podName, podUID, etc.) during mount operations.
-              type: string
-  version: v1alpha1
 
 ---
 
@@ -353,7 +274,7 @@ rules:
 #######################################
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: hpe-csi-node
   namespace: kube-system
@@ -371,6 +292,11 @@ spec:
       serviceAccount: hpe-csi-node-sa
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -529,33 +455,6 @@ kind: ServiceAccount
 metadata:
   name: hpe-csi-node-sa
   namespace: kube-system
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-role
-  namespace: kube-system
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-binding
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: hpe-csi-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io
 
 ---
 

--- a/yaml/csi-driver/hpe-csi-k8s-1.14.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.14.yaml
@@ -282,7 +282,7 @@ rules:
 #######################################
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: hpe-csi-node
   namespace: kube-system
@@ -300,6 +300,11 @@ spec:
       serviceAccount: hpe-csi-node-sa
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -458,33 +463,6 @@ kind: ServiceAccount
 metadata:
   name: hpe-csi-node-sa
   namespace: kube-system
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-role
-  namespace: kube-system
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-binding
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: hpe-csi-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io
 
 ---
 

--- a/yaml/csi-driver/hpe-csi-k8s-1.15.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.15.yaml
@@ -365,7 +365,7 @@ rules:
 #######################################
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: hpe-csi-node
   namespace: kube-system
@@ -383,6 +383,11 @@ spec:
       serviceAccount: hpe-csi-node-sa
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -541,33 +546,6 @@ kind: ServiceAccount
 metadata:
   name: hpe-csi-node-sa
   namespace: kube-system
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-role
-  namespace: kube-system
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-binding
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: hpe-csi-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io
 
 ---
 

--- a/yaml/csi-driver/hpe-csi-k8s-1.16.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.16.yaml
@@ -385,6 +385,11 @@ spec:
       serviceAccount: hpe-csi-node-sa
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -543,33 +548,6 @@ kind: ServiceAccount
 metadata:
   name: hpe-csi-node-sa
   namespace: kube-system
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-role
-  namespace: kube-system
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-binding
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: hpe-csi-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io
 
 ---
 

--- a/yaml/csi-driver/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/hpe-csi-k8s-1.17.yaml
@@ -514,6 +514,11 @@ spec:
       serviceAccount: hpe-csi-node-sa
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
@@ -667,33 +672,6 @@ kind: ServiceAccount
 metadata:
   name: hpe-csi-node-sa
   namespace: kube-system
-
----
-
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-role
-  namespace: kube-system
-rules:
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-driver-registrar-binding
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: hpe-csi-driver-registrar-role
-  apiGroup: rbac.authorization.k8s.io
 
 ---
 


### PR DESCRIPTION
A couple of nice to have suggestions on their 1.13 driver manifest:
https://github.com/hpe-storage/co-deployments/blob/master/yaml/csi-driver/hpe-csi-k8s-1.13.yaml
1. Remove installation of csinode and csidriver alpha CRDs. Those alpha features are disabled in Anthos 1.1, so the
 driver needs to (and is) functioning without those.
2. Use apps/v1 for the driver DaemonSet. This will be more future proof for when apps/v1beta2 is removed in 1.16:
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
3. Remove clusterrole and binding for node-driver-registrar. Version 1.1.0 doesn't require any kubernetes rbacs.
4. It's recommended that system-critical DaemonSets include a blanket toleration so that they will never be evicted:
https://groups.google.com/g/kubernetes-sig-storage/c/FjX5qM2wh6Q/m/5-1jzUgXCgAJ
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>