### PR TITLE
csi: propagate mounts under /host to host

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -91,6 +91,7 @@ spec:
               mountPropagation: "Bidirectional"
             - name: root-dir
               mountPath: /host
+              mountPropagation: "Bidirectional"
             - name: device-dir
               mountPath: /dev
             - name: log-dir

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
@@ -339,6 +339,7 @@ spec:
               mountPropagation: "Bidirectional"
             - name: root-dir
               mountPath: /host
+              mountPropagation: "Bidirectional"
             - name: device-dir
               mountPath: /dev
             - name: log-dir

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
@@ -347,6 +347,7 @@ spec:
               mountPropagation: "Bidirectional"
             - name: root-dir
               mountPath: /host
+              mountPropagation: "Bidirectional"
             - name: device-dir
               mountPath: /dev
             - name: log-dir

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
@@ -430,6 +430,7 @@ spec:
               mountPropagation: "Bidirectional"
             - name: root-dir
               mountPath: /host
+              mountPropagation: "Bidirectional"
             - name: device-dir
               mountPath: /dev
             - name: log-dir

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
@@ -432,6 +432,7 @@ spec:
               mountPropagation: "Bidirectional"
             - name: root-dir
               mountPath: /host
+              mountPropagation: "Bidirectional"
             - name: device-dir
               mountPath: /dev
             - name: log-dir

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -507,6 +507,7 @@ spec:
               mountPropagation: "Bidirectional"
             - name: root-dir
               mountPath: /host
+              mountPropagation: "Bidirectional"
             - name: device-dir
               mountPath: /dev
             - name: log-dir


### PR DESCRIPTION
* Problem:
  * Since mount/unmount are now done under /host(chroot), mounts under this needs to be
  * propagated back to host
* Implementation:
  * Propagate mounts done with /host as root.
* Testing: ran integration tests on both Ubuntu 18.04 and CentOS 7.6
* Review: gcostea, rkumar, sbyadarahalli
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>