### PR TITLE
Update csi-driver cluster role to be able to delete hpenodeinfo objects

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
@@ -257,7 +257,7 @@ metadata:
 rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/operators/hpe-csi-operator/deploy/rbac.yaml
+++ b/operators/hpe-csi-operator/deploy/rbac.yaml
@@ -98,6 +98,10 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+# Need permissions to let csi-driver load/unload/update hpenodeinfos resources
+  - apiGroups: ["storage.hpe.com"]
+    resources: ["hpenodeinfos"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 kind: ClusterRoleBinding

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
@@ -229,7 +229,7 @@ rules:
     verbs: ["get", "watch", "list"]
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
@@ -264,7 +264,7 @@ metadata:
 rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
@@ -347,7 +347,7 @@ metadata:
 rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
@@ -349,7 +349,7 @@ metadata:
 rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -423,7 +423,7 @@ metadata:
 rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]


### PR DESCRIPTION
* Bug: https://nimblejira.nimblestorage.com/browse/NLT-
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>