### PR TITLE
update csi attacher

### DIFF
--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -115,10 +115,11 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.0.0
+          image: quay.io/k8scsi/csi-attacher:v2.1.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--reconcile-sync=600s"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
* Problem:
Hitting the following issues
https://github.com/kubernetes/kubernetes/issues/84169
https://github.com/kubernetes/kubernetes/issues/86281
The problem is described in the comment below
https://github.com/kubernetes/kubernetes/issues/84169#issuecomment-545692734
```
* Kubernetes volume layer has code to periodically verify that volumes are attached.
It triggers every minute by default.
* For CSI, the Kubernetes volume code has NOT implemented "bulk verify volume attach", so kubernetes falls back to calling verify volumes attached PER NODE.
* The Kubernetes CSI code fetches a VolumeAttachment FOR EVERY ATTACHED VOLUME on the specified node as part of VolumesAreAttached(...) to check that it is verified.
kubernetes/pkg/volume/csi/csi_attacher.go
* Line 199 in 037751e
attach, err := c.k8s.StorageV1().VolumeAttachments().Get(attachID, meta.GetOptions{}) 
* For clusters with many nodes/attached volumes, this results in so many calls to fetch VolumeAttachment from the Kubernetes API server, that the kube-controller-manager starts to get throttled (as reported).
```
* Implementation:
There looks to be a short term fix and long term. But at the minimum the reconciliation logic in v2.1.1 of external-attacher prevents the loop as described at 
https://github.com/kubernetes/kubernetes/issues/79743
* Testing:
 verified on qa scale setup. Thanks to vidhu for verifying
Test results:
Deletion of 50+ pods.

Case 1: Image 2.0.0 : took more than 45 minutes for va to go away 
Case 2: Image 2.1.1 with default reconcile-sync took around 12-14 mins
Case 3: Image 2.1.1 with reconcile-sync of 10 mins completed in 5 mins

* Bug: https://nimblejira.nimblestorage.com/browse/CON-720