### PR TITLE
revert reconcile-sync fix

### DIFF
--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -119,7 +119,6 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
-            - "--reconcile-sync=600s"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
* Problem:
- there seems to still issues with drain when with
reconcile sync fix https://github.com/kubernetes/kubernetes/issues/86281#issuecomment-589780854
* Implementation:
setting disable-attach-detach-reconcile-sync to true in controller-manager as a work around fix 
* Testing:
- create,delete and drain tests