### PR TITLE
update csp artifactory search

### DIFF
--- a/build_tools/artifactory_search.json
+++ b/build_tools/artifactory_search.json
@@ -33,7 +33,15 @@
             "limit": 1
         },
         {
-            "pattern": "dcs-docker-local/hpestorage/nimble-csp/",
+            "pattern": "dcs-docker-local/hpestorage/nimble-csp/v1.1.0*",
+            "sortBy": [
+                "created"
+            ],
+            "sortOrder": "desc",
+            "limit": 1
+        },
+        {
+            "pattern": "dcs-docker-local/hpestorage/nimble-csp/edge*",
             "sortBy": [
                 "created"
             ],


### PR DESCRIPTION
* Problem:
 currently it looks for latest builds
* Implementation:
search for v1.1.0 as well as edge
* Testing:
    "path": "dcs-docker-local/hpestorage/nimble-csp/v1.1.0-2"
    "path": "dcs-docker-local/hpestorage/nimble-csp/edge-315"

Signed-off-by: Raunak Kumar <rkumar@nimblestorage.com>