### PR TITLE
co-deployments: add rbac required for pod monitor

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -112,6 +112,8 @@ spec:
               mountPath: /etc/kubernetes
             - name: hpeconfig
               mountPath: /etc/hpe-storage
+            - name: root-dir
+              mountPath: /host
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -120,7 +122,10 @@ spec:
             path: /var/log
         - name: k8s
           hostPath:
-             path: /etc/kubernetes
+            path: /etc/kubernetes
         - name: hpeconfig
           hostPath:
-              path: /etc/hpe-storage
+            path: /etc/hpe-storage
+        - name: root-dir
+          hostPath:
+            path: /

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
@@ -54,6 +54,12 @@ rules:
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
 {{- end }}
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
 
 ---
 

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
@@ -135,6 +135,8 @@ spec:
               mountPath: /etc/kubernetes
             - name: hpeconfig
               mountPath: /etc/hpe-storage
+            - name: root-dir
+              mountPath: /host
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -143,10 +145,13 @@ spec:
             path: /var/log
         - name: k8s
           hostPath:
-             path: /etc/kubernetes/
+            path: /etc/kubernetes/
         - name: hpeconfig
           hostPath:
-              path: /etc/hpe-storage/
+            path: /etc/hpe-storage/
+        - name: root-dir
+          hostPath:
+            path: /
 
 ---
 
@@ -196,6 +201,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
 
 ---
 

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
@@ -145,6 +145,8 @@ spec:
               mountPath: /etc/kubernetes
             - name: hpeconfig
               mountPath: /etc/hpe-storage
+            - name: root-dir
+              mountPath: /host
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -153,10 +155,13 @@ spec:
             path: /var/log
         - name: k8s
           hostPath:
-             path: /etc/kubernetes/
+            path: /etc/kubernetes/
         - name: hpeconfig
           hostPath:
-              path: /etc/hpe-storage/
+            path: /etc/hpe-storage/
+        - name: root-dir
+          hostPath:
+            path: /
 
 ---
 
@@ -206,7 +211,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
 
 ---
 

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
@@ -157,6 +157,8 @@ spec:
               mountPath: /etc/kubernetes
             - name: hpeconfig
               mountPath: /etc/hpe-storage
+            - name: root-dir
+              mountPath: /host
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -165,10 +167,13 @@ spec:
             path: /var/log
         - name: k8s
           hostPath:
-             path: /etc/kubernetes/
+            path: /etc/kubernetes/
         - name: hpeconfig
           hostPath:
-              path: /etc/hpe-storage/
+            path: /etc/hpe-storage/
+        - name: root-dir
+          hostPath:
+            path: /
 
 ---
 
@@ -218,7 +223,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
 
 ---
 

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
@@ -160,6 +160,8 @@ spec:
               mountPath: /etc/kubernetes
             - name: hpeconfig
               mountPath: /etc/hpe-storage
+            - name: root-dir
+              mountPath: /host
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -172,7 +174,9 @@ spec:
         - name: hpeconfig
           hostPath:
               path: /etc/hpe-storage/
-
+        - name: root-dir
+          hostPath:
+              path: /
 ---
 
 kind: ServiceAccount
@@ -221,6 +225,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
 
 ---
 

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -174,6 +174,8 @@ spec:
               mountPath: /etc/kubernetes
             - name: hpeconfig
               mountPath: /etc/hpe-storage
+            - name: root-dir
+              mountPath: /host
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -186,6 +188,9 @@ spec:
         - name: hpeconfig
           hostPath:
               path: /etc/hpe-storage/
+        - name: root-dir
+          hostPath:
+              path: /
 
 ---
 
@@ -241,7 +246,12 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
-
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
 
 ---
 

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
@@ -174,6 +174,8 @@ spec:
               mountPath: /etc/kubernetes
             - name: hpeconfig
               mountPath: /etc/hpe-storage
+            - name: root-dir
+              mountPath: /host
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -186,6 +188,9 @@ spec:
         - name: hpeconfig
           hostPath:
               path: /etc/hpe-storage/
+        - name: root-dir
+          hostPath:
+              path: /
 
 ---
 
@@ -241,7 +246,12 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
-
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
 
 ---
 


### PR DESCRIPTION
* Problem:
  * Pod monitor requires RBAC to check pods on dead nodes and delete them.
  * Pod monitor requires RBAC to check and delete volumeattachments from dead nodes.
  * CSI controller plugin needs to invoke host utilities(dnsdomainname), using chroot.
* Implementation:
  * Add required RBAC to csi-provisioner-role and mount root fs as /host with controller plugin.
* Testing: deployment on 1.17 and 1.18
* Review: gcostea, rkumar
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>