### PR TITLE
Added mandatory parameter provisioning_type to the storageclass

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/sc.yaml
+++ b/helm/charts/hpe-csi-driver/templates/sc.yaml
@@ -17,6 +17,7 @@ allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 parameters:
    description: {{ .Values.storageClass.parameters.volumeDescription }}
    accessProtocol: {{ .Values.storageClass.parameters.accessProtocol }}
+   provisioning_type: {{ .Values.storageClass.parameters.provisioningType }}
    csi.storage.k8s.io/fstype: {{ .Values.storageClass.parameters.fsType }}
    csi.storage.k8s.io/provisioner-secret-name: {{ .Values.backendType }}-secret
    csi.storage.k8s.io/provisioner-secret-namespace: {{ .Release.Namespace }}

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -41,6 +41,7 @@ storageClass:
     fsType: xfs
     volumeDescription: "Volume created by the HPE CSI Driver for Kubernetes"
     accessProtocol: "iscsi"
+    provisioningType: "tpvv"
 
 # CRD creation controls
 ## For HELM 3 CRD's are handled automatically without this flag.


### PR DESCRIPTION
The provisioning_type parameter in the storageclass is mandatory according to SCOD documentation. Also, when trying to run the CSI driver without it, it fails because it lacks a provisioning_type.

This PR adds the parameter to the storageclass so the Helm chart works out-of-the-box for primera3par devices.