### PR TITLE
helm: lint fix

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/nimble-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/nimble-csp.yaml
@@ -37,11 +37,11 @@ spec:
       {{- end }}
       containers:
         - name: nimble-csp
-        {{- if .Values.registry }}
-        image: {{ .Values.registry }}/hpestorage/nimble-csp:v1.3.0
-        {{- else }}
-        image: hpestorage/nimble-csp:v1.3.0
-        {{- end }}   
+          {{- if .Values.registry }}
+          image: {{ .Values.registry }}/hpestorage/nimble-csp:v1.3.0
+          {{- else }}
+          image: hpestorage/nimble-csp:v1.3.0
+          {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           ports:
             - containerPort: 8080


### PR DESCRIPTION
- helm lint didn't catch the error
- error was thrown as part of helm install --dry-run
install.go:180: [debug] WARNING: This chart or one of its subcharts contains CRDs. Rendering may fail or contain inaccuracies.
Error: YAML parse error on hpe-csi-driver/templates/nimble-csp.yaml: error converting YAML to JSON: yaml: line 20: did not find expected '-' indicator
helm.go:75: [debug] error converting YAML to JSON: yaml: line 20: did not find expected '-' indicator
YAML parse error on hpe-csi-driver/templates/nimble-csp.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort

Signed-off-by: Raunak <raunak.kumar@hpe.com>