### PR TITLE
CON-1395: Avoid FailedPreStopHook warning on hpe-csi-node termination

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -31,7 +31,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -36,10 +36,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=5"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -55,7 +51,7 @@ spec:
           imagePullPolicy: "Always"
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi/
+              mountPath: /csi
             - name: registration-dir
               mountPath: /registration
         - name: hpe-csi-driver
@@ -125,9 +121,11 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi.hpe.com
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
@@ -329,10 +329,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=5"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -341,7 +337,7 @@ spec:
           imagePullPolicy: "Always"
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi/
+              mountPath: /csi
             - name: registration-dir
               mountPath: /registration
         - name: hpe-csi-driver
@@ -397,9 +393,11 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi.hpe.com/
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.13.yaml
@@ -324,7 +324,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
@@ -331,7 +331,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.14.yaml
@@ -336,10 +336,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=5"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -348,7 +344,7 @@ spec:
           imagePullPolicy: "Always"
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi/
+              mountPath: /csi
             - name: registration-dir
               mountPath: /registration
         - name: hpe-csi-driver
@@ -414,9 +410,11 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi.hpe.com
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
@@ -419,10 +419,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=5"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -431,7 +427,7 @@ spec:
           imagePullPolicy: "Always"
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi/
+              mountPath: /csi
             - name: registration-dir
               mountPath: /registration
         - name: hpe-csi-driver
@@ -491,9 +487,11 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi.hpe.com
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.15.yaml
@@ -414,7 +414,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
@@ -511,7 +511,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.16.yaml
@@ -516,10 +516,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=5"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -528,7 +524,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi/
+              mountPath: /csi
             - name: registration-dir
               mountPath: /registration
         - name: hpe-csi-driver
@@ -588,9 +584,11 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi.hpe.com
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -759,7 +759,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -764,10 +764,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=5"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -775,7 +771,7 @@ spec:
               value: /var/lib/kubelet/plugins/csi.hpe.com/csi.sock
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi/
+              mountPath: /csi
             - name: registration-dir
               mountPath: /registration
         - name: hpe-csi-driver
@@ -837,9 +833,11 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi.hpe.com
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
@@ -765,10 +765,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=5"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -776,7 +772,7 @@ spec:
               value: /var/lib/kubelet/plugins/csi.hpe.com/csi.sock
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi/
+              mountPath: /csi
             - name: registration-dir
               mountPath: /registration
         - name: hpe-csi-driver
@@ -838,9 +834,11 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi.hpe.com
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
@@ -760,7 +760,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.19.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.19.yaml
@@ -773,7 +773,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.0.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.19.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.19.yaml
@@ -778,10 +778,6 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=5"
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -789,7 +785,7 @@ spec:
               value: /var/lib/kubelet/plugins/csi.hpe.com/csi.sock
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi/
+              mountPath: /csi
             - name: registration-dir
               mountPath: /registration
         - name: hpe-csi-driver
@@ -851,9 +847,11 @@ spec:
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins_registry
+            type: Directory
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/csi.hpe.com
+            type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
             path: /var/lib/kubelet


### PR DESCRIPTION
The csi-node-driver-registrar container in the hpe-csi-node daemonset defines
a pre-stop hook that runs a command in the container.  However, the container
does not include a shell command, so the hook execution fails with this error:
"exec: \"/bin/sh\": stat /bin/sh: no such file or directory".  Avoid the error
by removing the hook.