### PR TITLE
CSP selector and values.yaml cleanup

### DIFF
--- a/helm/charts/hpe-csi-driver/README.md
+++ b/helm/charts/hpe-csi-driver/README.md
@@ -19,14 +19,17 @@ Depending on which [Container Storage Provider](https://scod.hpedev.io/container
 
 The following table lists the configurable parameters of the chart and their default values.
 
-|  Parameter                |  Description                                                           |  Default     |
-|---------------------------|------------------------------------------------------------------------|--------------|
-| logLevel                  | Log level. Can be one of `info`, `debug`, `trace`, `warn` and `error`. | info         |
-| imagePullPolicy           | Image pull policy (`Always`, `IfNotPresent`, `Never`).                 | IfNotPresent |
-| disableNodeConformance    | Disable automatic installation of iSCSI/Multipath Packages.            | false        |
-| iscsi.chapUser            | Username for iSCSI CHAP authentication.                                | ""           |
-| iscsi.chapPassword        | Password for iSCSI CHAP authentication.                                | ""           |
-| registry                  | Registry to pull HPE CSI Driver container images from.                 | quay.io      |
+| Parameter              | Description                                                            | Default      |
+|------------------------|------------------------------------------------------------------------|--------------|
+| disable.cv             | Disable HPE Cloud Volumes CSP `Service` and `Deployment`.              | false        |
+| disable.nimble         | Disable HPE Nimble Storage CSP `Service` and `Deployment`.             | false        |
+| disable.primera        | Disable HPE Primera (3PAR) CSP `Service` and `Deployment`.             | false        |
+| disableNodeConformance | Disable automatic installation of iSCSI/Multipath Packages.            | false        |
+| imagePullPolicy        | Image pull policy (`Always`, `IfNotPresent`, `Never`).                 | IfNotPresent |
+| iscsi.chapUser         | Username for iSCSI CHAP authentication.                                | ""           |
+| iscsi.chapPassword     | Password for iSCSI CHAP authentication.                                | ""           |
+| logLevel               | Log level. Can be one of `info`, `debug`, `trace`, `warn` and `error`. | info         |
+| registry               | Registry to pull HPE CSI Driver container images from.                 | quay.io      |
 
 It's recommended to create a [values.yaml](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver) file from the corresponding release of the chart and edit it to fit the environment the chart is being deployed to. Download and edit [a sample file](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver).
 

--- a/helm/charts/hpe-csi-driver/templates/cv-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/cv-csp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disable.cv }}
 # (C) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 ---
 ### CSP Service ###
@@ -58,4 +59,4 @@ spec:
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 30
-
+{{- end }}

--- a/helm/charts/hpe-csi-driver/templates/nimble-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/nimble-csp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disable.nimble }}
 ---
 ### CSP Service ###
 kind: Service
@@ -61,4 +62,4 @@ spec:
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 30
-
+{{- end }}

--- a/helm/charts/hpe-csi-driver/templates/primera-3par-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/primera-3par-csp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disable.primera }}
 ---
 ### CSP Service ###
 kind: Service
@@ -63,3 +64,4 @@ spec:
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 30
+{{- end }}

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -1,24 +1,26 @@
-# Default values for hpe-csi-storage.
+# Default values for hpe-csi-driver Helm chart
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# image pull policy for all images in csi deployment
-imagePullPolicy: 'IfNotPresent'
+# Control CSP Service and Deployments for HPE storage products
+disable:
+  cv: false
+  nimble: false
+  primera: false
 
-# flavor
-flavor: kubernetes
-
-# log level for all csi driver components
-logLevel: info
-
-## For controlling automatic iscsi/multipath package installation (default: false)
+# For controlling automatic iscsi/multipath package installation
 disableNodeConformance: false
 
-# values for CHAP Authentication
+# imagePullPolicy applied for all hpe-csi-driver images
+imagePullPolicy: "IfNotPresent"
+
+# Cluster wide values for CHAP authentication
 iscsi:
   chapUser: ""
   chapPassword: ""
 
-# registry prefix for hpe csi images
-registry: "quay.io"
+# Log level for all hpe-csi-driver components
+logLevel: "info"
 
+# Registry prefix for hpe-csi-driver images
+registry: "quay.io"


### PR DESCRIPTION
Thank you community users @papanito and @Baykonur for this suggestion. This PR supersede PRs #225 and #218 in addition to:

- Cleaning up the default values file and table by organizing variables alphabetically.
- This change does not alter the current behavior of the chart and users need to selectively disable the unwanted CSPs.
- The `flavor` variable was not used anywhere in the chart. Removed.

Signed-off-by: Michael Mattsson <michael.mattsson@hpe.com>