### PR TITLE
Consistent tolerations between Helm/Operator and Advanced Install

### DIFF
--- a/yaml/csi-driver/edge/3par-primera-csp.yaml
+++ b/yaml/csi-driver/edge/3par-primera-csp.yaml
@@ -153,3 +153,12 @@ spec:
         - name: log-dir
           hostPath:
             path: /var/log
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30

--- a/yaml/csi-driver/edge/cv-csp.yaml
+++ b/yaml/csi-driver/edge/cv-csp.yaml
@@ -55,3 +55,12 @@ spec:
             value: "https://prod.cloudvolumes.hpe.com"
           ports:
           - containerPort: 8080
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -259,7 +259,15 @@ spec:
         - name: root-dir
           hostPath:
               path: /
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 kind: ServiceAccount
@@ -907,6 +915,15 @@ spec:
         - name: linux-config-file
           configMap:
             name: hpe-linux-config
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 apiVersion: v1

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
@@ -259,7 +259,15 @@ spec:
         - name: root-dir
           hostPath:
               path: /
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 kind: ServiceAccount
@@ -909,7 +917,15 @@ spec:
         - name: linux-config-file
           configMap:
             name: hpe-linux-config
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 apiVersion: v1

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.19.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.19.yaml
@@ -258,7 +258,15 @@ spec:
         - name: root-dir
           hostPath:
               path: /
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 kind: ServiceAccount
@@ -908,7 +916,15 @@ spec:
         - name: linux-config-file
           configMap:
             name: hpe-linux-config
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 apiVersion: v1

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.20.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.20.yaml
@@ -258,7 +258,15 @@ spec:
         - name: root-dir
           hostPath:
               path: /
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 kind: ServiceAccount
@@ -902,7 +910,15 @@ spec:
         - name: linux-config-file
           configMap:
             name: hpe-linux-config
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 apiVersion: v1

--- a/yaml/csi-driver/edge/nimble-csp.yaml
+++ b/yaml/csi-driver/edge/nimble-csp.yaml
@@ -58,3 +58,12 @@ spec:
         - name: log-dir
           hostPath:
             path: /var/log
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30

--- a/yaml/csi-driver/v1.4.0/3par-primera-csp.yaml
+++ b/yaml/csi-driver/v1.4.0/3par-primera-csp.yaml
@@ -153,3 +153,12 @@ spec:
         - name: log-dir
           hostPath:
             path: /var/log
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30

--- a/yaml/csi-driver/v1.4.0/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/v1.4.0/hpe-csi-k8s-1.17.yaml
@@ -259,7 +259,15 @@ spec:
         - name: root-dir
           hostPath:
               path: /
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 kind: ServiceAccount
@@ -904,6 +912,15 @@ spec:
         - name: linux-config-file
           configMap:
             name: hpe-linux-config
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 apiVersion: v1

--- a/yaml/csi-driver/v1.4.0/hpe-csi-k8s-1.18.yaml
+++ b/yaml/csi-driver/v1.4.0/hpe-csi-k8s-1.18.yaml
@@ -259,7 +259,15 @@ spec:
         - name: root-dir
           hostPath:
               path: /
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 kind: ServiceAccount
@@ -906,7 +914,15 @@ spec:
         - name: linux-config-file
           configMap:
             name: hpe-linux-config
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 apiVersion: v1

--- a/yaml/csi-driver/v1.4.0/hpe-csi-k8s-1.19.yaml
+++ b/yaml/csi-driver/v1.4.0/hpe-csi-k8s-1.19.yaml
@@ -258,7 +258,15 @@ spec:
         - name: root-dir
           hostPath:
               path: /
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 kind: ServiceAccount
@@ -905,7 +913,15 @@ spec:
         - name: linux-config-file
           configMap:
             name: hpe-linux-config
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 apiVersion: v1

--- a/yaml/csi-driver/v1.4.0/hpe-csi-k8s-1.20.yaml
+++ b/yaml/csi-driver/v1.4.0/hpe-csi-k8s-1.20.yaml
@@ -258,7 +258,15 @@ spec:
         - name: root-dir
           hostPath:
               path: /
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 kind: ServiceAccount
@@ -899,7 +907,15 @@ spec:
         - name: linux-config-file
           configMap:
             name: hpe-linux-config
-
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
 ---
 
 apiVersion: v1

--- a/yaml/csi-driver/v1.4.0/nimble-csp.yaml
+++ b/yaml/csi-driver/v1.4.0/nimble-csp.yaml
@@ -58,3 +58,12 @@ spec:
         - name: log-dir
           hostPath:
             path: /var/log
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30


### PR DESCRIPTION
Accidentally nuked my previous branch.

This PR brings the tolerations we've set in the Helm chart to the raw YAML files.

Signed-off-by: Michael Mattsson <michael.mattsson@hpe.com>