### PR TITLE
Reverting changes to read secrets from all namespaces

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-rbac.yaml
@@ -8,27 +8,14 @@ metadata:
 
 ---
 
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: hpe-csi-node-sa
-  namespace: {{ .Release.Namespace }}
-
----
-
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: hpe-csp-sa
-  namespace: {{ .Release.Namespace }}
-
----
-
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hpe-csi-provisioner-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "create"]
@@ -59,14 +46,14 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "17") }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "17") }}
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
     verbs: ["get", "list"]
-  {{- end }}
+{{- end }}
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "delete"]
@@ -108,6 +95,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
   {{- if and (eq .Capabilities.KubeVersion.Major "1") ( eq  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "12") }}
     resources: ["csinodeinfos"]
     verbs: ["get", "list", "watch"]
@@ -137,7 +127,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 
-  {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "17") }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "17") }}
 ---
 
 kind: ClusterRole
@@ -145,6 +135,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hpe-csi-snapshotter-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
@@ -191,9 +184,9 @@ roleRef:
   name: hpe-csi-snapshotter-role
   apiGroup: rbac.authorization.k8s.io
 
-  {{- end }}
+{{- end }}
 
-  {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "15") }}
+{{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "15") }}
 ---
 # Resizer must be able to work with PVCs, PVs, SCs.
 kind: ClusterRole
@@ -201,6 +194,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-resizer-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -300,6 +296,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -359,6 +358,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -413,6 +415,9 @@ metadata:
   name: csi-mutator-role
 rules:
   - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: [""]
@@ -438,6 +443,7 @@ subjects:
     name: hpe-csi-controller-sa
     # replace with non-default namespace name
     namespace: {{ .Release.Namespace }}
+
 roleRef:
   kind: ClusterRole
   name: csi-mutator-role
@@ -452,9 +458,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: csi-mutator-cfg
 rules:
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: RoleBinding
@@ -466,11 +472,12 @@ subjects:
   - kind: ServiceAccount
     name: hpe-csi-controller-sa
     namespace: {{ .Release.Namespace }}
+
 roleRef:
   kind: Role
   name: csi-mutator-cfg
   apiGroup: rbac.authorization.k8s.io
-  {{- end }}
+{{- end }}
 
 ---
 
@@ -478,6 +485,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hpe-csi-driver-role
+  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpenodeinfos"]
@@ -493,9 +501,12 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["storage.hpe.com"]
     resources: ["hpesnapshotgroupinfos"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]    
   - apiGroups: [""]
     resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["services"]
@@ -518,6 +529,14 @@ rules:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hpe-csi-node-sa
+  namespace: {{ .Release.Namespace }}
+
+---
+
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -532,6 +551,7 @@ subjects:
   - kind: ServiceAccount
     name: hpe-csp-sa
     namespace: {{ .Release.Namespace }}
+
 roleRef:
   kind: ClusterRole
   name: hpe-csi-driver-role
@@ -539,60 +559,8 @@ roleRef:
 
 ---
 
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
+kind: ServiceAccount
+apiVersion: v1
 metadata:
-  name: hpe-csi-secret-get
+  name: hpe-csp-sa
   namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get-binding
-  namespace: {{ .Release.Namespace }}
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: {{ .Release.Namespace }}
-  - kind: ServiceAccount
-    name: hpe-csp-sa
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-get
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch
-  namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch-binding
-  namespace: {{ .Release.Namespace }}
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-controller-sa
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-watch
-  apiGroup: rbac.authorization.k8s.io
-

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.17.yaml
@@ -270,8 +270,8 @@ spec:
           tolerationSeconds: 30
 ---
 
-apiVersion: v1
 kind: ServiceAccount
+apiVersion: v1
 metadata:
   name: hpe-csi-controller-sa
   namespace: hpe-storage
@@ -283,6 +283,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: hpe-csi-provisioner-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "create"]
@@ -363,6 +366,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
 
 ---
 
@@ -439,6 +445,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-resizer-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -538,6 +547,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -598,6 +610,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -651,6 +666,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-mutator-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -724,6 +742,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get"]
@@ -913,8 +934,8 @@ metadata:
 
 ---
 
-apiVersion: v1
 kind: ServiceAccount
+apiVersion: v1
 metadata:
   name: hpe-csp-sa
   namespace: hpe-storage
@@ -938,63 +959,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: hpe-csi-driver-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get
-  namespace: hpe-storage
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get-binding
-  namespace: hpe-storage
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: hpe-storage
-  - kind: ServiceAccount
-    name: hpe-csp-sa
-    namespace: hpe-storage
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-get
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch
-  namespace: hpe-storage
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch-binding
-  namespace: hpe-storage
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-controller-sa
-    namespace: hpe-storage
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-watch
   apiGroup: rbac.authorization.k8s.io

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.18.yaml
@@ -284,6 +284,9 @@ metadata:
   name: hpe-csi-provisioner-role
 rules:
   - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "create"]
   - apiGroups: [""]
@@ -363,6 +366,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
 
 ---
 
@@ -439,6 +445,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-resizer-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -539,6 +548,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -599,6 +611,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -652,6 +667,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-mutator-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -725,6 +743,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get"]
@@ -940,63 +961,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: hpe-csi-driver-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get
-  namespace: hpe-storage
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get-binding
-  namespace: hpe-storage
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: hpe-storage
-  - kind: ServiceAccount
-    name: hpe-csp-sa
-    namespace: hpe-storage
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-get
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch
-  namespace: hpe-storage
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch-binding
-  namespace: hpe-storage
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-controller-sa
-    namespace: hpe-storage
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-watch
   apiGroup: rbac.authorization.k8s.io

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.19.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.19.yaml
@@ -283,6 +283,9 @@ metadata:
   name: hpe-csi-provisioner-role
 rules:
   - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "create"]
   - apiGroups: [""]
@@ -362,6 +365,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
 
 ---
 
@@ -438,6 +444,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-resizer-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -538,6 +547,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -598,6 +610,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -651,6 +666,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-mutator-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -723,6 +741,9 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["services"]
@@ -939,63 +960,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: hpe-csi-driver-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get
-  namespace: hpe-storage
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get-binding
-  namespace: hpe-storage
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: hpe-storage
-  - kind: ServiceAccount
-    name: hpe-csp-sa
-    namespace: hpe-storage
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-get
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch
-  namespace: hpe-storage
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch-binding
-  namespace: hpe-storage
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-controller-sa
-    namespace: hpe-storage
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-watch
   apiGroup: rbac.authorization.k8s.io

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.20.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.20.yaml
@@ -283,6 +283,9 @@ metadata:
   name: hpe-csi-provisioner-role
 rules:
   - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "create"]
   - apiGroups: [""]
@@ -362,6 +365,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments/status"]
     verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
 
 ---
 
@@ -438,6 +444,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-resizer-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -538,6 +547,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -598,6 +610,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "get", "update"]
@@ -651,6 +666,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-mutator-role
 rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "update", "patch"]
@@ -723,6 +741,9 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["services"]
@@ -933,63 +954,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: hpe-csi-driver-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get
-  namespace: hpe-storage
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-get-binding
-  namespace: hpe-storage
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-node-sa
-    namespace: hpe-storage
-  - kind: ServiceAccount
-    name: hpe-csp-sa
-    namespace: hpe-storage
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-get
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch
-  namespace: hpe-storage
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: hpe-csi-secret-watch-binding
-  namespace: hpe-storage
-subjects:
-  - kind: ServiceAccount
-    name: hpe-csi-controller-sa
-    namespace: hpe-storage
-roleRef:
-  kind: Role
-  name: hpe-csi-secret-watch
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Reverting [PR#238](https://github.com/hpe-storage/co-deployments/pull/238) to read the secrets from all namespaces as per the discussion .
@sneharai4 @raunakkumar please review