### PR TITLE
remove flavor from hpe csi driver operator CR definition

### DIFF
--- a/operators/hpe-csi-operator/deploy/crds/storage.hpe.com_hpecsidrivers_crd.yaml
+++ b/operators/hpe-csi-operator/deploy/crds/storage.hpe.com_hpecsidrivers_crd.yaml
@@ -35,9 +35,6 @@ spec:
         spec:
           description: HPECSIDriverSpec defines the desired state of HPECSIDriver
           properties:
-            flavor:
-              description: Flavor of the CO orchestrator
-              type: string
             imagePullPolicy:
               description: Image Pull Policy for HPE CSI driver images
               type: string

--- a/operators/hpe-csi-operator/deploy/crds/storage.hpe.com_v1_hpecsidriver_cr.yaml
+++ b/operators/hpe-csi-operator/deploy/crds/storage.hpe.com_v1_hpecsidriver_cr.yaml
@@ -11,9 +11,6 @@ spec:
   # image pull policy for all images in csi deployment
   imagePullPolicy: 'IfNotPresent'
 
-  # flavor
-  flavor: kubernetes
-
   # log level for all csi driver components
   logLevel: info
 

--- a/operators/hpe-csi-operator/deploy/generated/api/v1/hpecsidriver_types.go
+++ b/operators/hpe-csi-operator/deploy/generated/api/v1/hpecsidriver_types.go
@@ -29,8 +29,6 @@ type HPECSIDriverSpec struct {
 
 	// Image Pull Policy for HPE CSI driver images
 	ImagePullPolicy string `json:"imagePullPolicy"`
-	// Flavor of the CO orchestrator
-	Flavor string `json:"flavor"`
 	// Default logLevel for HPE CSI driver deployments
 	LogLevel string `json:"logLevel"`
 	// DisableNodeConformance disables automatic installation of iscsi/multipath packages


### PR DESCRIPTION
Problem:
- with the introductions of helm schema checks, operator installations fail because of invalid
params

Signed-off-by: Raunak <raunak.kumar@hpe.com>