### PR TITLE
update helm-operator image

### DIFF
--- a/operators/hpe-csi-operator/Dockerfile
+++ b/operators/hpe-csi-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v1.3.2
+FROM quay.io/operator-framework/helm-operator:v1.8
 LABEL name="csi-driver-operator" \
       maintainer="HPE Storage Containers Team" \
       vendor="HPE" \


### PR DESCRIPTION
Problem: redhat cert suite found critical_vulnerabilities with 1.3 version,
after updating it to 1.8, the cert security suite passed
https://quay.io/repository/operator-framework/helm-operator?tab=tags 1.8 is the minimum version with no vulnerabilities
Signed-off-by: Raunak <raunak.kumar@hpe.com>