### PR TITLE
[csi-snapshotter][4.0.0] fix private registry namespace

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -76,7 +76,7 @@ spec:
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
           image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0
           {{- else if .Values.registry }}
-          image: {{ .Values.registry }}/k8scsi/csi-snapshotter:v4.0.0
+          image: {{ .Values.registry }}/sig-storage/csi-snapshotter:v4.0.0
           {{- else }}
           image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.0
           {{- end }}


### PR DESCRIPTION
When using a private registry, `csi-snapshotter` points to a wrong namespace.
Since the CSI driver 2.0, the new `csi-snapshotter` is at `sig-storage` and not `k8scsi` used in former versions