### PR TITLE
Add a smoke test for each of the metrics Helm charts

### DIFF
--- a/helm/charts/hpe-array-exporter/Chart.yaml
+++ b/helm/charts/hpe-array-exporter/Chart.yaml
@@ -1,6 +1,8 @@
-apiVersion: v1
+apiVersion: v2
+name: hpe-array-exporter
 version: "1.0.0"
 appVersion: "1.0.0"
+kubeVersion: ">= 1.18.0"
 annotations:
   artifacthub.io/prerelease: "true"
   artifacthub.io/license: Apache-2.0
@@ -14,7 +16,6 @@ maintainers:
   email: hpe-containers-dev@hpe.com
 sources:
 - https://github.com/hpe-storage/co-deployments
-name: hpe-array-exporter
 home: https://hpe.com/storage/containers
 keywords:
   - HPE

--- a/helm/charts/hpe-array-exporter/README.md
+++ b/helm/charts/hpe-array-exporter/README.md
@@ -22,7 +22,7 @@ The chart has these configurable parameters and default values.
 | service.type | The type of Service to create, ClusterIP for access solely from within the cluster or NodePort to provide access from outside the cluster (`ClusterIP`, `NodePort`). | ClusterIP |
 | service.port | The TCP port at which to expose access to storage array metrics within the cluster. | 9090 |
 | service.nodePort | The TCP port at which to expose access to storage array metrics externally at each cluster node, if the Service type is NodePort and automatic assignment is not desired. | *none* |
-| service.customLabels | Labels to add to the Service, for example to include target labels in a ServiceMonitor scrape configuration. | *none* |
+| service.customLabels | Labels to add to the Service, for example to include target labels in a ServiceMonitor scrape configuration. | {} |
 
 Use of a values.yaml file is recommended.  Download and edit [a sample values.yaml file](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/array-exporter) corresponding to the chart version and edit the settings according to the deployment environment.
 

--- a/helm/charts/hpe-array-exporter/templates/hpe-array-exporter.yaml
+++ b/helm/charts/hpe-array-exporter/templates/hpe-array-exporter.yaml
@@ -21,11 +21,7 @@ spec:
     spec:
       containers:
         - name: array-exporter
-          {{- if .Values.registry }}
           image: {{ .Values.registry }}/hpestorage/array-exporter:v1.0.0
-          {{- else }}
-          image: quay.io/hpestorage/array-exporter:v1.0.0
-          {{- end }}
           ports:
             - containerPort: 8080
           args:
@@ -59,8 +55,8 @@ metadata:
     chart: {{ template "hpe-array-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-    {{- range $key, $value := $service.customLabels }}
-    {{ $key }}: {{ $value | quote }}
+    {{- with $service.customLabels }}
+{{ toYaml . | indent 4 }}
     {{- end }}
 spec:
   {{- $serviceType := $service.type | default "ClusterIP" }}

--- a/helm/charts/hpe-array-exporter/templates/tests/test-hpe-array-exporter.yaml
+++ b/helm/charts/hpe-array-exporter/templates/tests/test-hpe-array-exporter.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "hpe-array-exporter.fullname" . }}-test"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "hpe-array-exporter.name" . }}
+    chart: {{ template "hpe-array-exporter.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: array-exporter-test
+      image: busybox
+      imagePullPolicy: "IfNotPresent"
+      command: ['wget']
+      args:
+      - "-O-"
+      - '{{ include "hpe-array-exporter.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics'
+  restartPolicy: Never

--- a/helm/charts/hpe-array-exporter/values.yaml
+++ b/helm/charts/hpe-array-exporter/values.yaml
@@ -38,5 +38,5 @@ service:
 
   # Labels to add to the Service, for example to include target labels
   # in a ServiceMonitor scrape configuration.
-  #customLabels:
+  customLabels: {}
   #  array: 192.168.0.1

--- a/helm/charts/hpe-csi-info-metrics/Chart.yaml
+++ b/helm/charts/hpe-csi-info-metrics/Chart.yaml
@@ -1,6 +1,8 @@
-apiVersion: v1
+apiVersion: v2
+name: hpe-csi-info-metrics
 version: "1.0.0"
 appVersion: "1.0.0"
+kubeVersion: ">= 1.18.0"
 annotations:
   artifacthub.io/prerelease: "true"
   artifacthub.io/license: Apache-2.0
@@ -14,7 +16,6 @@ maintainers:
   email: hpe-containers-dev@hpe.com
 sources:
 - https://github.com/hpe-storage/co-deployments
-name: hpe-csi-info-metrics
 home: https://hpe.com/storage/containers
 keywords:
   - HPE

--- a/helm/charts/hpe-csi-info-metrics/README.md
+++ b/helm/charts/hpe-csi-info-metrics/README.md
@@ -22,7 +22,7 @@ The chart has these configurable parameters and default values.
 | service.type | The type of Service to create, ClusterIP for access solely from within the cluster or NodePort to provide access from outside the cluster (`ClusterIP`, `NodePort`). | ClusterIP |
 | service.port | The TCP port at which to expose access to info metrics within the cluster. | 9090 |
 | service.nodePort | The TCP port at which to expose access to info metrics externally at each cluster node, if the Service type is NodePort and automatic assignment is not desired. | *none* |
-| service.customLabels | Labels to add to the Service, for example to include target labels in a ServiceMonitor scrape configuration. | *none* |
+| service.customLabels | Labels to add to the Service, for example to include target labels in a ServiceMonitor scrape configuration. | {} |
 
 Use of a values.yaml file is recommended.  Download and edit [a sample values.yaml file](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-info-metrics) corresponding to the chart version and edit the settings according to the deployment environment.
 

--- a/helm/charts/hpe-csi-info-metrics/templates/hpe-csi-info-metrics.yaml
+++ b/helm/charts/hpe-csi-info-metrics/templates/hpe-csi-info-metrics.yaml
@@ -54,11 +54,7 @@ spec:
       serviceAccount: hpe-csi-info-metrics-serviceaccount
       containers:
         - name: csi-info-metrics
-          {{- if .Values.registry }}
           image: {{ .Values.registry }}/hpestorage/csi-info-metrics:v1.0.0
-          {{- else }}
-          image: quay.io/hpestorage/csi-info-metrics:v1.0.0
-          {{- end }}
           ports:
           - containerPort: 9099
           args:
@@ -80,9 +76,9 @@ metadata:
   name: hpe-csi-info-metrics-service
   namespace: {{ .Release.Namespace }}
   labels:
-    app: hpe-csi-info-metrics-service
-    {{- range $key, $value := $service.customLabels }}
-    {{ $key }}: {{ $value | quote }}
+    app: hpe-csi-info-metrics
+    {{- with $service.customLabels }}
+{{ toYaml . | indent 4 }}
     {{- end }}
 spec:
   {{- $serviceType := $service.type | default "ClusterIP" }}

--- a/helm/charts/hpe-csi-info-metrics/templates/tests/test-hpe-csi-info-metrics.yaml
+++ b/helm/charts/hpe-csi-info-metrics/templates/tests/test-hpe-csi-info-metrics.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "hpe-csi-info-metrics-test"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: hpe-csi-info-metrics
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: csi-info-metrics-test
+      image: busybox
+      imagePullPolicy: "IfNotPresent"
+      command: ['wget']
+      args:
+      - "-O-"
+      - 'hpe-csi-info-metrics-service.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/metrics'
+  restartPolicy: Never

--- a/helm/charts/hpe-csi-info-metrics/values.yaml
+++ b/helm/charts/hpe-csi-info-metrics/values.yaml
@@ -33,5 +33,5 @@ service:
 
   # Labels to add to the Service, for example to include target labels
   # in a ServiceMonitor scrape configuration.
-  #customLabels:
+  customLabels: {}
   #  k8s_cluster: mycluster

--- a/helm/values/array-exporter/v1.0.0/values.yaml
+++ b/helm/values/array-exporter/v1.0.0/values.yaml
@@ -38,5 +38,5 @@ service:
 
   # Labels to add to the Service, for example to include target labels
   # in a ServiceMonitor scrape configuration.
-  #customLabels:
+  customLabels: {}
   #  array: 192.168.0.1

--- a/helm/values/csi-info-metrics/v1.0.0/values.yaml
+++ b/helm/values/csi-info-metrics/v1.0.0/values.yaml
@@ -33,5 +33,5 @@ service:
 
   # Labels to add to the Service, for example to include target labels
   # in a ServiceMonitor scrape configuration.
-  #customLabels:
+  customLabels: {}
   #  k8s_cluster: mycluster

--- a/yaml/array-exporter/edge/hpe-array-exporter.yaml
+++ b/yaml/array-exporter/edge/hpe-array-exporter.yaml
@@ -59,10 +59,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: hpe-array-exporter-service
+  name: hpe-array-exporter
   namespace: hpe-storage
   labels:
-    app: hpe-array-exporter-service
+    app: hpe-array-exporter
     # Optionally add labels, for example to be included in Prometheus
     # metrics via a targetLabels setting in a ServiceMonitor spec
     #array: 192.168.0.1

--- a/yaml/array-exporter/v1.0.0/hpe-array-exporter.yaml
+++ b/yaml/array-exporter/v1.0.0/hpe-array-exporter.yaml
@@ -59,10 +59,10 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: hpe-array-exporter-service
+  name: hpe-array-exporter
   namespace: hpe-storage
   labels:
-    app: hpe-array-exporter-service
+    app: hpe-array-exporter
     # Optionally add labels, for example to be included in Prometheus
     # metrics via a targetLabels setting in a ServiceMonitor spec
     #array: 192.168.0.1

--- a/yaml/csi-info-metrics/edge/hpe-csi-info-metrics.yaml
+++ b/yaml/csi-info-metrics/edge/hpe-csi-info-metrics.yaml
@@ -87,7 +87,7 @@ metadata:
   name: hpe-csi-info-metrics-service
   namespace: hpe-storage
   labels:
-    app: hpe-csi-info-metrics-service
+    app: hpe-csi-info-metrics
     # Optionally add labels, for example to be included in Prometheus
     # metrics via a targetLabels setting in a ServiceMonitor spec
     #k8s_cluster: example-1


### PR DESCRIPTION
* In the hpe-array-exporter and hpe-csi-info-metrics Helm charts, add a test
case to validate the basic function of a release (installed chart).
* Update to Helm API version 2.
* Add a Kubernetes version constraint of 1.18+.