### PR TITLE
Global attribute

### DIFF
--- a/helm/charts/hpe-csi-driver/values.schema.json
+++ b/helm/charts/hpe-csi-driver/values.schema.json
@@ -164,7 +164,7 @@
             "minimum": 60,
             "maximum": 360
         },
-	"global": {}
+        "global": {}
     },
     "additionalProperties": false
 }

--- a/helm/charts/hpe-csi-driver/values.schema.json
+++ b/helm/charts/hpe-csi-driver/values.schema.json
@@ -163,7 +163,8 @@
             "default": 60,
             "minimum": 60,
             "maximum": 360
-        }
+        },
+	"global": {}
     },
     "additionalProperties": false
 }


### PR DESCRIPTION
When charts are linted at a macro level, such as the Rancher partner repo or a chart is a sub chart being dependent on elsewhere, the global attribute needs to be defined as empty in the schema. We do not have to push a new chart at this time as the diff is managed separately with Rancher but it's an extra step to keep track of.

```
~/code/co-deployments/helm/charts/hpe-csi-driver$ helm lint
==> Linting .

1 chart(s) linted, 0 chart(s) failed
~/code/co-deployments/helm/charts/hpe-csi-driver$ git diff HEAD~1
diff --git a/helm/charts/hpe-csi-driver/values.schema.json b/helm/charts/hpe-csi-driver/values.schema.json
index 99c21a8..e8085b0 100644
--- a/helm/charts/hpe-csi-driver/values.schema.json
+++ b/helm/charts/hpe-csi-driver/values.schema.json
@@ -163,7 +163,8 @@
             "default": 60,
             "minimum": 60,
             "maximum": 360
-        }
+        },
+       "global": {}
     },
     "additionalProperties": false
 }
```

Signed-off-by: Michael Mattsson <michael.mattsson@gmail.com>