### PR TITLE
Added the env variable for csp logging

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/primera-3par-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/primera-3par-csp.yaml
@@ -68,6 +68,9 @@ spec:
           image: quay.io/hpestorage/alletra-9000-primera-and-3par-csp:v2.0.0
           {{- end }}        
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/yaml/csi-driver/edge/3par-primera-csp.yaml
+++ b/yaml/csi-driver/edge/3par-primera-csp.yaml
@@ -165,6 +165,9 @@ spec:
         - name: primera3par-csp
           image: quay.io/hpestorage/alletra-9000-primera-and-3par-csp:v2.0.0
           imagePullPolicy: Always
+          env:
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
           ports:
           - containerPort: 8080
           volumeMounts:


### PR DESCRIPTION
@sneharai4 @raunakkumar Please review
Added env variable to have the CSP logs as per the logLevel mentioned.
CON-2329 ,3PAR CSP should honor Helm chart logLevel

3PAR/Primera CSP is using default trace level of logging. The customer should have the option to dial down logging to match the logLevel available to them to configure in the Helm chart.