### PR TITLE
#54 add annotations, affinity, nodeselector, tolerations support

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -15,11 +15,19 @@ spec:
     matchLabels:
       app: hpe-csi-controller
   template:
+{{- with (.Values.hpeCSIController).annotations }}
+    annotations:
+{{ toYaml . | indent 6}}
+{{- end }}
     metadata:
       labels:
         app: hpe-csi-controller
         role: hpe-csi
     spec:
+{{- with (.Values.hpeCSIController).affinity }}
+      affinity:
+{{ toYaml . | indent 8}}
+{{- end }}
       serviceAccountName: hpe-csi-controller-sa
       {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "17") }}
       priorityClassName: system-cluster-critical
@@ -214,6 +222,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+{{- with (.Values.hpeCSIController).nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8}}
+{{- end }}
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -238,3 +250,6 @@ spec:
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 30
+{{- with (.Values.hpeCSIController).tolerations }}
+{{ toYaml . | indent 8}}
+{{ end }}

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -14,11 +14,19 @@ spec:
     matchLabels:
       app: hpe-csi-node
   template:
+{{- with (.Values.hpeCSINode).annotations }}
+    annotations:
+{{ toYaml . | indent 6}}
+{{- end }}
     metadata:
       labels:
         app: hpe-csi-node
         role: hpe-csi
     spec:
+{{- with (.Values.hpeCSINode).affinity }}
+      affinity:
+{{ toYaml . | indent 8}}
+{{- end }}
       serviceAccountName: hpe-csi-node-sa
       {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "17") }}
       priorityClassName: system-node-critical
@@ -139,6 +147,10 @@ spec:
             - name: linux-config-file
               mountPath: /opt/hpe-storage/nimbletune/config.json
               subPath: config.json
+{{- with (.Values.hpeCSINode).nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8}}
+{{- end }}
       volumes:
         - name: registration-dir
           hostPath:
@@ -199,3 +211,6 @@ spec:
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 30
+{{- with (.Values.hpeCSINode).tolerations }}
+{{ toYaml . | indent 8}}
+{{ end }}

--- a/helm/charts/hpe-csi-driver/templates/nimble-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/nimble-csp.yaml
@@ -50,10 +50,18 @@ spec:
       app: nimble-csp
   replicas: 1
   template:
+{{- with (.Values.nimleCSP).annotations }}
+    annotations:
+{{ toYaml . | indent 6}}
+{{- end }}
     metadata:
       labels:
         app: nimble-csp
     spec:
+{{- with (.Values.nimleCSP).affinity }}
+      affinity:
+{{ toYaml . | indent 8}}
+{{- end }}
       serviceAccountName: hpe-csp-sa
       {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "17") }}
       priorityClassName: system-cluster-critical
@@ -71,6 +79,10 @@ spec:
           volumeMounts:
             - name: log-dir
               mountPath: /var/log
+{{- with (.Values.nimleCSP).nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8}}
+{{- end }}
       volumes:
         - name: log-dir
           hostPath:
@@ -84,4 +96,7 @@ spec:
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 30
+{{- with (.Values.nimleCSP).tolerations }}
+{{ toYaml . | indent 8}}
+{{ end }}
 {{- end }}

--- a/helm/charts/hpe-csi-driver/templates/primera-3par-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/primera-3par-csp.yaml
@@ -52,10 +52,18 @@ spec:
       app: primera3par-csp
   replicas: 1
   template:
+{{- with (.Values.primera3parCSP).annotations }}
+    annotations:
+{{ toYaml . | indent 6}}
+{{- end }}
     metadata:
       labels:
         app: primera3par-csp
     spec:
+{{- with (.Values.primera3parCSP).affinity }}
+      affinity:
+{{ toYaml . | indent 8}}
+{{- end }}
       serviceAccountName: hpe-csp-sa
       {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "17") }}
       priorityClassName: system-cluster-critical
@@ -78,6 +86,10 @@ spec:
           volumeMounts:
             - name: log-dir
               mountPath: /var/log
+{{- with (.Values.primera3parCSP).nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8}}
+{{- end }}
       volumes:
         - name: log-dir
           hostPath:
@@ -91,4 +103,7 @@ spec:
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 30
+{{- with (.Values.primera3parCSP).tolerations }}
+{{ toYaml . | indent 8}}
+{{ end }}
 {{- end }}

--- a/helm/charts/hpe-csi-driver/values.schema.json
+++ b/helm/charts/hpe-csi-driver/values.schema.json
@@ -86,6 +86,74 @@
             "type": "boolean",
             "default": false
         },
+        "hpeCSIController": {
+            "$id": "#/properties/hpeCSIController",
+            "title": "Disable node conformance",
+            "description": "Disabling node conformance forces the cluster administrator to install required packages and ensure the correct node services are started to use external block storage.",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "affinity": {
+                    "$id": "#/properties/hpeCSIController/properties/affinity",
+                    "title": "Affinity for the hpe-csi-controller deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "annotations": {
+                    "$id": "#/properties/hpeCSIController/properties/annotations",
+                    "title": "Annotations for the hpe-csi-controller deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "$id": "#/properties/hpeCSIController/properties/nodeSelector",
+                    "title": "NodeSelector for the hpe-csi-controller deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "tolerations": {
+                    "$id": "#/properties/hpeCSIController/properties/tolerations",
+                    "title": "Tolerations for the hpe-csi-controller deployment",
+                    "type": "array",
+                    "default": []
+                }
+            },
+            "additionalProperties": false
+        },
+        "hpeCSINode": {
+            "$id": "#/properties/hpeCSINode",
+            "title": "Disable node conformance",
+            "description": "Disabling node conformance forces the cluster administrator to install required packages and ensure the correct node services are started to use external block storage.",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "affinity": {
+                    "$id": "#/properties/hpeCSINode/properties/affinity",
+                    "title": "Affinity for the hpe-csi-node daemonset",
+                    "type": "object",
+                    "default": {}
+                },
+                "annotations": {
+                    "$id": "#/properties/hpeCSINode/properties/annotations",
+                    "title": "Annotations for the hpe-csi-node daemonset",
+                    "type": "object",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "$id": "#/properties/hpeCSINode/properties/nodeSelector",
+                    "title": "NodeSelector for the hpe-csi-node daemonset",
+                    "type": "object",
+                    "default": {}
+                },
+                "tolerations": {
+                    "$id": "#/properties/hpeCSINode/properties/tolerations",
+                    "title": "Tolerations for the hpe-csi-node daemonset",
+                    "type": "array",
+                    "default": []
+                }
+            },
+            "additionalProperties": false
+        },
         "imagePullPolicy": {
             "$id": "#/properties/imagePullPolicy",
             "title": "CSI driver image pull policy",
@@ -130,6 +198,74 @@
             "type": "string",
             "default": "info",
             "enum": [ "info", "debug", "trace", "warn", "error" ]
+        },
+        "nimleCSP": {
+            "$id": "#/properties/nimleCSP",
+            "title": "Disable node conformance",
+            "description": "Disabling node conformance forces the cluster administrator to install required packages and ensure the correct node services are started to use external block storage.",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "affinity": {
+                    "$id": "#/properties/nimleCSP/properties/affinity",
+                    "title": "Affinity for the nimble-csp deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "annotations": {
+                    "$id": "#/properties/nimleCSP/properties/annotations",
+                    "title": "Annotations for the nimble-csp deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "$id": "#/properties/nimleCSP/properties/nodeSelector",
+                    "title": "NodeSelector for the nimble-csp deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "tolerations": {
+                    "$id": "#/properties/nimleCSP/properties/tolerations",
+                    "title": "Tolerations for the nimble-csp deployment",
+                    "type": "array",
+                    "default": []
+                }
+            },
+            "additionalProperties": false
+        },
+        "primera3parCSP": {
+            "$id": "#/properties/primera3parCSP",
+            "title": "Disable node conformance",
+            "description": "Disabling node conformance forces the cluster administrator to install required packages and ensure the correct node services are started to use external block storage.",
+            "type": "object",
+            "default": {},
+            "properties": {
+                "affinity": {
+                    "$id": "#/properties/primera3parCSP/properties/affinity",
+                    "title": "Affinity for the primera3par-csp deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "annotations": {
+                    "$id": "#/properties/primera3parCSP/properties/annotations",
+                    "title": "Annotations for the primera3par-csp deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "$id": "#/properties/primera3parCSP/properties/nodeSelector",
+                    "title": "NodeSelector for the primera3par-csp deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "tolerations": {
+                    "$id": "#/properties/primera3parCSP/properties/tolerations",
+                    "title": "Tolerations for the primera3par-csp deployment",
+                    "type": "array",
+                    "default": []
+                }
+            },
+            "additionalProperties": false
         },
         "registry": {
             "$id": "#/properties/registry",


### PR DESCRIPTION
I rendered the chart without and with my changes using the default `values.yaml` and compared the result without finding any diff.

Additionally I tested my changes with the following adjusted `values.yaml`:

```
# Default values for hpe-csi-driver Helm chart
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.

# Control CSP Service and Deployments for HPE storage products
disable:
  nimble: false
  primera: false
  alletra6000: false
  alletra9000: false

# For controlling automatic iscsi/multipath package installation
disableNodeConformance: false

# imagePullPolicy applied for all hpe-csi-driver images
imagePullPolicy: "IfNotPresent"

# Cluster wide values for CHAP authentication
iscsi:
  chapUser: ""
  chapPassword: ""

# Log level for all hpe-csi-driver components
logLevel: "info"

# Registry prefix for hpe-csi-driver images
registry: "quay.io"

# Kubelet root directory path
kubeletRootDir: "/var/lib/kubelet/"

# NodeGetVolumestats will be called by default, set true to disable the call 
disableNodeGetVolumeStats: false

hpeCSIController:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux1
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 1
        preference:
          matchExpressions:
          - key: another-node-label-key
            operator: In
            values:
            - another-node-label-value1
  annotations:
    mycustom: annotation1
  nodeSelector:
    node-role.kubernetes.io/infra: "1"
  tolerations:
    - effect: NoSchedule
      key: node-role.kubernetes.io/infra1
      value: reserved
    - effect: NoExecute
      key: node-role.kubernetes.io/infra1
      value: reserved

hpeCSINode:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux2
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 1
        preference:
          matchExpressions:
          - key: another-node-label-key
            operator: In
            values:
            - another-node-label-value2
  annotations:
    mycustom: annotation2
  nodeSelector:
    node-role.kubernetes.io/infra: "2"
  tolerations:
    - effect: NoSchedule
      key: node-role.kubernetes.io/infra2
      value: reserved
    - effect: NoExecute
      key: node-role.kubernetes.io/infra2
      value: reserved

nimleCSP:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux3
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 1
        preference:
          matchExpressions:
          - key: another-node-label-key
            operator: In
            values:
            - another-node-label-value3
  annotations:
    mycustom: annotation3
  nodeSelector:
    node-role.kubernetes.io/infra: "3"
  tolerations:
    - effect: NoSchedule
      key: node-role.kubernetes.io/infra3
      value: reserved
    - effect: NoExecute
      key: node-role.kubernetes.io/infra3
      value: reserved

primera3parCSP:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/os
            operator: In
            values:
            - linux4
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 1
        preference:
          matchExpressions:
          - key: another-node-label-key
            operator: In
            values:
            - another-node-label-value4
  annotations:
    mycustom: annotation4
  nodeSelector:
    node-role.kubernetes.io/infra: "4"
  tolerations:
    - effect: NoSchedule
      key: node-role.kubernetes.io/infra4
      value: reserved
    - effect: NoExecute
      key: node-role.kubernetes.io/infra5
      value: reserved
```