### PR TITLE
Update canonical name for SIG storage images

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -36,11 +36,11 @@ spec:
       containers:
         - name: csi-provisioner
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           {{- else if .Values.registry }}
           image: {{ .Values.registry }}/sig-storage/csi-provisioner:v3.3.0
           {{- else }}
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           {{- end }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -58,11 +58,11 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-attacher
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           {{- else if .Values.registry }}
           image: {{ .Values.registry }}/sig-storage/csi-attacher:v3.5.0
           {{- else }}
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           {{- end }}
           args:
             - "--v=5"
@@ -80,11 +80,11 @@ spec:
         - name: csi-snapshotter
         {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "20") }}
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           {{- else if .Values.registry }}
           image: {{ .Values.registry }}/sig-storage/csi-snapshotter:v5.0.1
           {{- else }}
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           {{- end }}
         {{- end }}
           args:
@@ -100,11 +100,11 @@ spec:
         {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "15") }}
         - name: csi-resizer
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
           {{- else if .Values.registry }}
           image: {{ .Values.registry }}/sig-storage/csi-resizer:v1.6.0
           {{- else }}
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
           {{- end }}
           args:
             - "--csi-address=$(ADDRESS)"

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -35,11 +35,11 @@ spec:
       containers:
         - name: csi-node-driver-registrar
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
           {{- else if .Values.registry }}
           image: {{ .Values.registry }}/sig-storage/csi-node-driver-registrar:v2.6.1
           {{- else }}
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
           {{- end}} 
           args:
             - "--csi-address=$(ADDRESS)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.22.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.22.yaml
@@ -120,7 +120,7 @@ spec:
             value: "1"
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -134,7 +134,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -146,7 +146,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -158,7 +158,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -804,7 +804,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.23.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.23.yaml
@@ -120,7 +120,7 @@ spec:
             value: "1"
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -134,7 +134,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -146,7 +146,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -158,7 +158,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -804,7 +804,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.24.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.24.yaml
@@ -120,7 +120,7 @@ spec:
             value: "1"
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -134,7 +134,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -146,7 +146,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -158,7 +158,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -804,7 +804,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.25.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.25.yaml
@@ -120,7 +120,7 @@ spec:
             value: "1"
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -134,7 +134,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -146,7 +146,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -158,7 +158,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -804,7 +804,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"


### PR DESCRIPTION
SIG storage is transitioning the registry DNS name to registry.k8s.io.

Signed-off-by: Michael Mattsson <michael.mattsson@gmail.com>