### PR TITLE
Update SIG Storage images

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -36,11 +36,11 @@ spec:
       containers:
         - name: csi-provisioner
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
           {{- else if .Values.registry }}
-          image: {{ .Values.registry }}/sig-storage/csi-provisioner:v3.3.0
+          image: {{ .Values.registry }}/sig-storage/csi-provisioner:v3.5.0
           {{- else }}
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
           {{- end }}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -58,11 +58,11 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-attacher
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
           {{- else if .Values.registry }}
-          image: {{ .Values.registry }}/sig-storage/csi-attacher:v3.5.1
+          image: {{ .Values.registry }}/sig-storage/csi-attacher:v4.3.0
           {{- else }}
-          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
           {{- end }}
           args:
             - "--v=5"
@@ -80,11 +80,11 @@ spec:
         - name: csi-snapshotter
         {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "20") }}
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
           {{- else if .Values.registry }}
-          image: {{ .Values.registry }}/sig-storage/csi-snapshotter:v5.0.1
+          image: {{ .Values.registry }}/sig-storage/csi-snapshotter:v6.2.2
           {{- else }}
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
           {{- end }}
         {{- end }}
           args:
@@ -100,11 +100,11 @@ spec:
         {{- if and (eq .Capabilities.KubeVersion.Major "1") ( ge  ( trimSuffix "+" .Capabilities.KubeVersion.Minor ) "15") }}
         - name: csi-resizer
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
           {{- else if .Values.registry }}
-          image: {{ .Values.registry }}/sig-storage/csi-resizer:v1.6.0
+          image: {{ .Values.registry }}/sig-storage/csi-resizer:v1.8.0
           {{- else }}
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
           {{- end }}
           args:
             - "--csi-address=$(ADDRESS)"

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -35,11 +35,11 @@ spec:
       containers:
         - name: csi-node-driver-registrar
           {{- if and (.Values.registry) (eq .Values.registry "quay.io") }}
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
           {{- else if .Values.registry }}
-          image: {{ .Values.registry }}/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: {{ .Values.registry }}/sig-storage/csi-node-driver-registrar:v2.8.0
           {{- else }}
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
           {{- end}}
           args:
             - "--csi-address=$(ADDRESS)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.24.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.24.yaml
@@ -120,7 +120,7 @@ spec:
             value: "1"
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -134,7 +134,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -146,7 +146,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -158,7 +158,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -804,7 +804,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.25.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.25.yaml
@@ -120,7 +120,7 @@ spec:
             value: "1"
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v3.3.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -134,7 +134,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v3.5.1
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -146,7 +146,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -158,7 +158,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v1.6.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -804,7 +804,7 @@ spec:
             value: "1"
       containers:
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.1
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.27.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.27.yaml
@@ -1,5 +1,5 @@
 # Configuration to deploy the HPE CSI driver compatible with
-# Kubernetes = v1.26
+# Kubernetes = v1.27
 #
 # example usage: kubectl create -f <this_file>
 


### PR DESCRIPTION
Passes CSI e2e on Kubernetes 1.27. Does not include HPE CSI/CSP specific tests. Requires full QA validation and sign offs.

```
[ReportAfterSuite] Kubernetes e2e JUnit report
test/e2e/framework/test_context.go:593
[ReportAfterSuite] PASSED [0.113 seconds]
------------------------------

Ran 91 of 7486 Specs in 4797.250 seconds
SUCCESS! -- 91 Passed | 0 Failed | 0 Pending | 7395 Skipped
PASS
```