### PR TITLE
Separate community/certified bundles

### DIFF
--- a/operators/hpe-csi-operator/.gitignore
+++ b/operators/hpe-csi-operator/.gitignore
@@ -1,2 +1,4 @@
 csi-driver-operator
 cache
+prep
+init

--- a/operators/hpe-csi-operator/Makefile
+++ b/operators/hpe-csi-operator/Makefile
@@ -6,12 +6,15 @@ REPO_NAME ?= quay.io/myrepo
 RH_REPO_NAME=registry.connect.redhat.com/hpestorage
 COMMUNITY_OUTPUT=destinations/community-operators/current-version
 CERTIFIED_OUTPUT=destinations/certified-operators/current-version
+CERTIFIED_KUBE_PROXY=registry.redhat.io/openshift4/ose-kube-rbac-proxy:latest
 NAMESPACE ?= hpe-storage
 VANITY_NAME ?= hpe-csi-operator
 IMAGE_NAME ?= csi-driver-operator
 BUNDLE_NAME ?= csi-driver-operator-bundle
+OCP_BUNDLE_NAME ?= csi-driver-operator-bundle-ocp
 IMG ?= $(REPO_NAME)/$(IMAGE_NAME):v$(VERSION)
 BUNDLE_IMG ?= $(REPO_NAME)/$(BUNDLE_NAME):v$(VERSION)
+OCP_BUNDLE_IMG ?= $(REPO_NAME)/$(OCP_BUNDLE_NAME):v$(VERSION)
 BUNDLE_CHANNELS ?= stable
 PLATFORMS ?= linux/arm64,linux/amd64
 
@@ -21,9 +24,9 @@ undeploy:
 
 clean: undeploy
 	# Delete build
-	test -f $(IMAGE_NAME) || rm -rf $(IMAGE_NAME)
+	rm -rf "init" "prep" "$(IMAGE_NAME)"
 
-init: clean
+init:
 	# Creat temp space
 	mkdir $(IMAGE_NAME)
 
@@ -34,9 +37,11 @@ init: clean
 		--version v1 \
 		--kind HPECSIDriver \
 		--project-name hpe-csi-operator \
-		--helm-chart=../../../helm/charts/hpe-csi-driver
+		--helm-chart hpe-csi-driver \
+		--helm-chart-repo https://hpe-storage.github.io/co-deployments
+	touch init
 
-build: init
+prep: init
 	# Populate with our sources
 	mkdir -p $(IMAGE_NAME)/config/manifests/bases
 	cp -f sources/hpecsidrivers.storage.hpe.com.crd.yaml \
@@ -47,7 +52,7 @@ build: init
 	cp -f sources/role.yaml $(IMAGE_NAME)/config/rbac/
 
 	# Fix memory on the manager.
-	sed -i.remove -e "s/memory: 128Mi/memory: 512Mi/g" $(IMAGE_NAME)/config/manager/manager.yaml && \
+	sed -i.remove -e "s/memory: 128Mi/memory: 1Gi/g" $(IMAGE_NAME)/config/manager/manager.yaml && \
 		rm -f $(IMAGE_NAME)/config/manager/manager.yaml.remove
 	
 	# Dockerfile for operator
@@ -60,48 +65,33 @@ build: init
 	cd $(IMAGE_NAME); docker-buildx build --progress=plain --no-cache \
 	--provenance=false --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
 
-	# Create bundle manifests
+	# Sample CSI driver instance
+	cp -f $(IMAGE_NAME)/config/samples/storage_v1_hpecsidriver.yaml \
+		destinations/hpecsidriver-v${VERSION}-sample.yaml
+	cp -f $(IMAGE_NAME)/config/samples/storage_v1_hpecsidriver.yaml \
+		destinations/hpecsidriver-latest-sample.yaml
+	touch prep
+
+community: prep
+	# Create community bundle manifests
 	cd $(IMAGE_NAME); make bundle CHANNELS=$(BUNDLE_CHANNELS) IMG="$(IMG)" BUNDLE_IMG="$(BUNDLE_IMG)" VERSION="$(VERSION)" USE_IMAGE_DIGESTS="true"
 
-	# Dockerfile for bundle
+	# Dockerfile for community bundle
 	sed -i.remove -e "s/^FROM.*//g" $(IMAGE_NAME)/bundle.Dockerfile && \
 		rm -f $(IMAGE_NAME)/bundle.Dockerfile.remove
 	cat sources/bundle.Dockerfile $(IMAGE_NAME)/bundle.Dockerfile \
 		> $(IMAGE_NAME)/bundle.Dockerfile-tmp && \
 		mv $(IMAGE_NAME)/bundle.Dockerfile-tmp $(IMAGE_NAME)/bundle.Dockerfile
 
-	# Annotations
-	cat sources/annotations.*.yaml | tee -a $(IMAGE_NAME)/bundle/metadata/annotations.yaml
+	# Annotations for community bundle
+	cat sources/annotations.community.yaml | tee -a $(IMAGE_NAME)/bundle/metadata/annotations.yaml
 
-	# Create bundle image for testing
+	# Create community bundle image for testing
 	cd $(IMAGE_NAME); make bundle-build bundle-push IMG="$(IMG)" BUNDLE_IMG="$(BUNDLE_IMG)" VERSION="$(VERSION)" USE_IMAGE_DIGESTS="true"
 
-	# Sample CSI driver instance
-	cp -f $(IMAGE_NAME)/config/samples/storage_v1_hpecsidriver.yaml \
-		destinations/hpecsidriver-v${VERSION}-sample.yaml
-	cp -f $(IMAGE_NAME)/config/samples/storage_v1_hpecsidriver.yaml \
-		destinations/hpecsidriver-latest-sample.yaml
-
-        # Validate bundle
+        # Validate community bundle
 	operator-sdk bundle validate $(BUNDLE_IMG) --select-optional suite=operatorframework
 
-deploy:
-	# Run bundle
-	- kubectl create ns $(NAMESPACE)
-	operator-sdk run bundle --timeout 5m $(BUNDLE_IMG) -n $(NAMESPACE)
-
-	# Instantiate HPECSIDriver
-	kubectl apply -n $(NAMESPACE) -f destinations/hpecsidriver-v${VERSION}-sample.yaml
-
-certified:
-	# Create certified-operators content
-	rm -rf $(CERTIFIED_OUTPUT)/*
-	cp -f -a $(IMAGE_NAME)/bundle/* $(CERTIFIED_OUTPUT)
-	sed -i.remove -e "s|$(REPO_NAME)|$(RH_REPO_NAME)|g" -e "/replaces: /d" \
-		$(CERTIFIED_OUTPUT)/manifests/hpe-csi-operator.clusterserviceversion.yaml && \
-		rm -f $(CERTIFIED_OUTPUT)/manifests/hpe-csi-operator.clusterserviceversion.yaml.remove
-
-community:
 	# Create community-operators content
 	rm -rf $(COMMUNITY_OUTPUT)/*
 	cp -f -a $(IMAGE_NAME)/bundle/* $(COMMUNITY_OUTPUT)
@@ -109,5 +99,58 @@ community:
 		$(COMMUNITY_OUTPUT)/manifests/hpe-csi-operator.v$(VERSION).clusterserviceversion.yaml
 		cp -f $(IMAGE_NAME)/bundle.Dockerfile $(COMMUNITY_OUTPUT)/Dockerfile
 
-scorecard:
-	operator-sdk scorecard $(BUNDLE_IMG) -n $(NAMESPACE)
+community-deploy:
+	# Run community bundle
+	- kubectl create ns $(NAMESPACE)
+	operator-sdk run bundle --timeout 5m $(BUNDLE_IMG) -n $(NAMESPACE)
+
+	# Instantiate HPECSIDriver
+	kubectl apply -n $(NAMESPACE) -f destinations/hpecsidriver-v${VERSION}-sample.yaml
+
+community-scorecard:
+	# Create community scorecard
+	operator-sdk scorecard --wait-time 5m $(BUNDLE_IMG) -n $(NAMESPACE)
+
+certified: prep
+        # Replace kube-proxy for certified bundle
+	sed -i.remove -e "s#gcr.io/kubebuilder/kube-rbac-proxy.*#$(CERTIFIED_KUBE_PROXY)#" \
+		$(IMAGE_NAME)/config/default/manager_auth_proxy_patch.yaml && \
+		rm -f $(IMAGE_NAME)/config/default/manager_auth_proxy_patch.yaml.remove
+
+	# Create certified bundle manifests
+	cd $(IMAGE_NAME); make bundle CHANNELS="$(BUNDLE_CHANNELS)" IMG="$(IMG)" BUNDLE_IMG="$(OCP_BUNDLE_IMG)" VERSION="$(VERSION)" USE_IMAGE_DIGESTS="true"
+
+	# Dockerfile for certified bundle
+	sed -i.remove -e "s/^FROM.*//g" $(IMAGE_NAME)/bundle.Dockerfile && \
+		rm -f $(IMAGE_NAME)/bundle.Dockerfile.remove
+	cat sources/bundle.Dockerfile $(IMAGE_NAME)/bundle.Dockerfile \
+		> $(IMAGE_NAME)/bundle.Dockerfile-tmp && \
+		mv $(IMAGE_NAME)/bundle.Dockerfile-tmp $(IMAGE_NAME)/bundle.Dockerfile
+
+	# Annotations for certified bundle
+	cat sources/annotations.certified.yaml | tee -a $(IMAGE_NAME)/bundle/metadata/annotations.yaml
+
+	# Create certified bundle image for testing
+	cd $(IMAGE_NAME); make bundle-build bundle-push IMG="$(IMG)" BUNDLE_IMG="$(OCP_BUNDLE_IMG)" VERSION="$(VERSION)" USE_IMAGE_DIGESTS="true"
+
+        # Validate certified bundle
+	operator-sdk bundle validate $(OCP_BUNDLE_IMG) --select-optional suite=operatorframework
+
+	# Create certified-operators content
+	rm -rf $(CERTIFIED_OUTPUT)/*
+	cp -f -a $(IMAGE_NAME)/bundle/* $(CERTIFIED_OUTPUT)
+	sed -i.remove -e "s|$(REPO_NAME)|$(RH_REPO_NAME)|g" -e "/replaces: /d" \
+		$(CERTIFIED_OUTPUT)/manifests/hpe-csi-operator.clusterserviceversion.yaml && \
+		rm -f $(CERTIFIED_OUTPUT)/manifests/hpe-csi-operator.clusterserviceversion.yaml.remove
+
+certified-deploy:
+	# Run certified bundle
+	- oc create ns $(NAMESPACE)
+	operator-sdk run bundle --timeout 5m $(OCP_BUNDLE_IMG) -n $(NAMESPACE)
+
+	# Instantiate HPECSIDriver
+	oc apply -n $(NAMESPACE) -f destinations/hpecsidriver-v${VERSION}-sample.yaml
+
+certified-scorecard:
+	# Create certified scorecard
+	operator-sdk scorecard --wait-time 5m $(OCP_BUNDLE_IMG) -n $(NAMESPACE)


### PR DESCRIPTION
The next build will separate the bundle between community and certified. The certified will use the kube rbac proxy advised by Red Hat.

- https://redhat-connect.gitbook.io/certified-operator-guide/helm-operators/building-a-helm-operator/update-the-controller-manager

The increase in memory for the controller manager (L55) stems from an issue a customer is suffering from.