### PR TITLE
Support for CHAP Secret name and namespace as environment variables

### DIFF
--- a/helm/charts/hpe-csi-driver/README.md
+++ b/helm/charts/hpe-csi-driver/README.md
@@ -38,6 +38,8 @@ The following table lists the configurable parameters of the chart and their def
 | disableNodeConfiguration  | Disables node conformance and configuration.`*`                        | false            |
 | disableNodeGetVolumeStats | Disable NodeGetVolumeStats call to CSI driver.                         | false            |
 | imagePullPolicy           | Image pull policy (`Always`, `IfNotPresent`, `Never`).                 | IfNotPresent     |
+| iscsi.chapSecretName      | Secret containing the CHAP username and password                       | ""               |
+| iscsi.chapSecretNamespace | Namespace where the CHAP secret is located                             | ""               |
 | logLevel                  | Log level. Can be one of `info`, `debug`, `trace`, `warn` and `error`. | info             |
 | kubeletRootDir            | The kubelet root directory path.                                       | /var/lib/kubelet |
 | controller.labels         | Additional labels for HPE CSI Driver controller Pods.                  | {}               |
@@ -62,6 +64,16 @@ The following table lists the configurable parameters of the chart and their def
 It's recommended to create a [values.yaml](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver) file from the corresponding release of the chart and edit it to fit the environment the chart is being deployed to. Download and edit [a sample file](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver).
 
 **Note:** The chart is installed with all components and features enabled using reasonable defaults if no tweaks are needed.
+
+These are the bare minimum required parameters for a successful deployment to an iSCSI environment if CHAP authentication is required.
+(Below iSCSI configuration is to have backward compatibility. From version 1.30 onwards, CHAP secret name and namespace can be passed as storage class parameters.)
+```
+iscsi:
+  chapSecretName: "<secretName>"
+  chapSecretNamespace: "<secretNamespace>"
+```
+
+Tweak any additional parameters to suit the environment or as prescribed by HPE.
 
 ### Installing the chart
 

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -110,6 +110,12 @@ spec:
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: LOG_LEVEL
               value: {{ .Values.logLevel }}
+            {{ if and .Values.iscsi.chapSecretName .Values.iscsi.chapSecretNamespace }}
+            - name: CHAP_SECRET_NAME
+              value: {{ .Values.iscsi.chapSecretName }}
+            - name: CHAP_SECRET_NAMESPACE
+              value: {{ .Values.iscsi.chapSecretNamespace }}
+            {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           volumeMounts:
             - name: socket-dir

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -116,6 +116,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{ if and .Values.iscsi.chapSecretName .Values.iscsi.chapSecretNamespace }}
+            - name: CHAP_SECRET_NAME
+              value: {{ .Values.iscsi.chapSecretName }}
+            - name: CHAP_SECRET_NAMESPACE
+              value: {{ .Values.iscsi.chapSecretNamespace }}
+            {{- end }}
             {{ if .Values.disableNodeConformance -}}
             - name: DISABLE_NODE_CONFORMANCE
               value: "true"

--- a/helm/charts/hpe-csi-driver/templates/primera-3par-csp.yaml
+++ b/helm/charts/hpe-csi-driver/templates/primera-3par-csp.yaml
@@ -91,6 +91,12 @@ spec:
               value: "35"
             - name: CRD_CLIENT_CONFIG_BURST
               value: "20"
+            {{ if and .Values.iscsi.chapSecretName .Values.iscsi.chapSecretNamespace }}
+            - name: CHAP_SECRET_NAME
+              value: {{ .Values.iscsi.chapSecretName }}
+            - name: CHAP_SECRET_NAMESPACE
+              value: {{ .Values.iscsi.chapSecretNamespace }}
+            {{- end }}
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/helm/charts/hpe-csi-driver/values.schema.json
+++ b/helm/charts/hpe-csi-driver/values.schema.json
@@ -15,6 +15,10 @@
             "disableNodeConformance": false,
             "disableNodeConfiguration": false,
             "imagePullPolicy": "IfNotPresent",
+            "iscsi": {
+                "chapSecretName": "",
+                "chapSecretNamespace": ""
+            },
             "logLevel": "info",
             "kubeletRootDir": "/var/lib/kubelet/",
             "disableNodeGetVolumeStats": false,
@@ -46,6 +50,7 @@
         "disableNodeConformance",
         "disableNodeConfiguration",
         "imagePullPolicy",
+        "iscsi",
         "logLevel",
         "kubeletRootDir",
         "disableNodeGetVolumeStats",
@@ -129,6 +134,35 @@
             "type": "string",
             "default": "IfNotPresent",
             "enum": [ "Always", "IfNotPresent", "Never" ]
+        },
+        "iscsi": {
+            "$id": "#/properties/iscsi",
+            "title": "iSCSI CHAP secret name and namespace",
+            "type": "object",
+            "default": 
+                {
+                    "chapSecretName": "",
+                    "chapSecretNamespace": ""
+                },
+            "required": [
+                "chapSecretName",
+                "chapSecretNamespace"
+            ],
+            "properties": {
+                "chapSecretName": {
+                    "$id": "#/properties/iscsi/properties/chapSecretName",
+                    "title": "CHAP secret name",
+                    "type": "string",
+                    "default": ""
+                },
+                "chapSecretNamespace": {
+                    "$id": "#/properties/iscsi/properties/chapSecretNamespace",
+                    "title": "CHAP secret namespace",
+                    "type": "string",
+                    "default": ""
+                }
+            },
+            "additionalProperties": false
         },
         "logLevel": {
             "$id": "#/properties/logLevel",

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -19,6 +19,11 @@ disableNodeConfiguration: false
 # imagePullPolicy applied for all hpe-csi-driver images
 imagePullPolicy: "IfNotPresent"
 
+# Cluster wide values for CHAP authentication
+iscsi:
+  chapSecretName: ""
+  chapSecretNamespace: ""
+
 # Log level for all hpe-csi-driver components
 logLevel: "info"
 

--- a/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
+++ b/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
@@ -157,6 +157,19 @@ spec:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:text"
+          - displayName: iSCSI Configuration
+            description: "Configuration for iSCSI."
+            path: iscsi
+          - displayName: iSCSI CHAP Secret Name
+            description: "The name of the secret containing the CHAP username and password."
+            path: iscsi.chapSecretName
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:text"
+          - displayName: iSCSI CHAP Secret Namespace
+            description: "The namespace where the CHAP secret is located."
+            path: iscsi.chapSecretNamespace
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:text"
           - displayName: Kubelet root dir
             description: "The kubelet root directory path."
             path: kubeletRootDir

--- a/operators/hpe-csi-operator/sources/hpecsidrivers.storage.hpe.com.crd.yaml
+++ b/operators/hpe-csi-operator/sources/hpecsidrivers.storage.hpe.com.crd.yaml
@@ -68,6 +68,17 @@ spec:
               imagePullPolicy:
                 description: Image Pull Policy for HPE CSI driver images
                 type: string
+              iscsi:
+                description: Iscsi parameters to be configured
+                properties:
+                  chapSecretName:
+                    type: string
+                  chapSecretNamespace:
+                    type: string
+                required:
+                - chapSecretName
+                - chapSecretNamespace
+                type: object
               images:
                 description: HPE CSI Operator Images
                 properties:

--- a/yaml/csi-driver/edge/3par-primera-csp.yaml
+++ b/yaml/csi-driver/edge/3par-primera-csp.yaml
@@ -60,6 +60,10 @@ spec:
             value: "35"
           - name: CRD_CLIENT_CONFIG_BURST
             value: "20"
+          - name: CHAP_SECRET_NAME
+            value: ""
+          - name: CHAP_SECRET_NAMESPACE
+            value: hpe-storage
           ports:
           - containerPort: 8080
           volumeMounts:

--- a/yaml/csi-driver/edge/hpe-csi-k8s-1.30.yaml
+++ b/yaml/csi-driver/edge/hpe-csi-k8s-1.30.yaml
@@ -752,6 +752,10 @@ spec:
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: LOG_LEVEL
               value: trace
+            - name: CHAP_SECRET_NAME
+              value: ""
+            - name: CHAP_SECRET_NAMESPACE
+              value: hpe-storage
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
@@ -990,6 +994,10 @@ spec:
               value: "false"
             - name: DISABLE_NODE_CONFIGURATION
               value: "false"
+            - name: CHAP_SECRET_NAME
+              value: ""
+            - name: CHAP_SECRET_NAMESPACE
+              value: hpe-storage
           imagePullPolicy: "IfNotPresent"
           securityContext:
             privileged: true


### PR DESCRIPTION
This iSCSI configuration is to have backward compatibility. From version 2.5.0 onwards, CHAP secret name and namespace can be passed as storage class parameters.