### PR TITLE
Add option to disable pre-install hook

### DIFF
--- a/helm/charts/hpe-csi-driver/README.md
+++ b/helm/charts/hpe-csi-driver/README.md
@@ -27,38 +27,39 @@ Depending on which [Container Storage Provider](https://scod.hpedev.io/container
 
 The following table lists the configurable parameters of the chart and their default values.
 
-| Parameter                 | Description                                                                    | Default          |
-|---------------------------|--------------------------------------------------------------------------------|------------------|
-| disable.nimble            | Disable HPE Nimble Storage CSP `Service`.                                      | false            |
-| disable.primera           | Disable HPE Primera (and 3PAR) CSP `Service`.                                  | false            |
-| disable.alletra6000       | Disable HPE Alletra 5000/6000 CSP `Service`.                                   | false            |
-| disable.alletra9000       | Disable HPE Alletra 9000 CSP `Service`.                                        | false            |
-| disable.alletraStorageMP  | Disable HPE Alletra Storage MP CSP `Service`.                                  | false            |
-| disableNodeConformance    | Disable automatic installation of iSCSI, multipath and NFS packages.           | false            |
-| disableNodeConfiguration  | Disables node conformance and configuration.`*`                                | false            |
-| disableNodeGetVolumeStats | Disable NodeGetVolumeStats call to CSI driver.                                 | false            |
-| disableNodeMonitor        | Disables the Node Monitor that manages stale storage resources.                | false            |
-| disableHostDeletion       | Disables host deletion by the CSP when no volumes are associated with the host.| false            |
-| imagePullPolicy           | Image pull policy (`Always`, `IfNotPresent`, `Never`).                         | IfNotPresent     |
-| iscsi.chapSecretName      | Secret containing chapUser and chapPassword for iSCSI                          | ""               |
-| logLevel                  | Log level. Can be one of `info`, `debug`, `trace`, `warn` and `error`.         | info             |
-| kubeletRootDir            | The kubelet root directory path.                                               | /var/lib/kubelet |
-| controller.labels         | Additional labels for HPE CSI Driver controller Pods.                          | {}               |
-| controller.nodeSelector   | Node labels for HPE CSI Driver controller Pods assignment.                     | {}               |
-| controller.affinity       | Affinity rules for the HPE CSI Driver controller Pods.                         | {}               |
-| controller.tolerations    | Node taints to tolerate for the HPE CSI Driver controller Pods.                | []               |
-| controller.resources      | A resource block with requests and limits for controller containers.           | From values.yaml |
-| csp.labels                | Additional labels for CSP Pods.                                                | {}               |
-| csp.nodeSelector          | Node labels for CSP Pods assignment.                                           | {}               |
-| csp.affinity              | Affinity rules for the CSP Pods.                                               | {}               |
-| csp.tolerations           | Node taints to tolerate for the CSP Pods.                                      | []               |
-| csp.resources             | A resource block with requests and limits for CSP containers.                  | From values.yaml |
-| node.labels               | Additional labels for HPE CSI Driver node Pods.                                | {}               |
-| node.nodeSelector         | Node labels for HPE CSI Driver node Pods assignment.                           | {}               |
-| node.affinity             | Affinity rules for the HPE CSI Driver node Pods.                               | {}               |
-| node.tolerations          | Node taints to tolerate for the HPE CSI Driver node Pods.                      | []               |
-| node.resources            | A resource block with requests and limits for node containers.                 | From values.yaml |
-| images                    | Key/value pairs of HPE CSI Driver runtime images.                              | From values.yaml |
+| Parameter                 | Description                                                                                        | Default          |
+|---------------------------|----------------------------------------------------------------------------------------------------|------------------|
+| disable.nimble            | Disable HPE Nimble Storage CSP `Service`.                                                          | false            |
+| disable.primera           | Disable HPE Primera (and 3PAR) CSP `Service`.                                                      | false            |
+| disable.alletra6000       | Disable HPE Alletra 5000/6000 CSP `Service`.                                                       | false            |
+| disable.alletra9000       | Disable HPE Alletra 9000 CSP `Service`.                                                            | false            |
+| disable.alletraStorageMP  | Disable HPE Alletra Storage MP CSP `Service`.                                                      | false            |
+| disableNodeConformance    | Disable automatic installation of iSCSI, multipath and NFS packages.                               | false            |
+| disableNodeConfiguration  | Disables node conformance and configuration.`*`                                                    | false            |
+| disableNodeGetVolumeStats | Disable NodeGetVolumeStats call to CSI driver.                                                     | false            |
+| disableNodeMonitor        | Disables the Node Monitor that manages stale storage resources.                                    | false            |
+| disableHostDeletion       | Disables host deletion by the CSP when no volumes are associated with the host.                    | false            |
+| disablePreInstallHooks    | Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems. | false            |
+| imagePullPolicy           | Image pull policy (`Always`, `IfNotPresent`, `Never`).                                             | IfNotPresent     |
+| iscsi.chapSecretName      | Secret containing chapUser and chapPassword for iSCSI                                              | ""               |
+| logLevel                  | Log level. Can be one of `info`, `debug`, `trace`, `warn` and `error`.                             | info             |
+| kubeletRootDir            | The kubelet root directory path.                                                                   | /var/lib/kubelet |
+| controller.labels         | Additional labels for HPE CSI Driver controller Pods.                                              | {}               |
+| controller.nodeSelector   | Node labels for HPE CSI Driver controller Pods assignment.                                         | {}               |
+| controller.affinity       | Affinity rules for the HPE CSI Driver controller Pods.                                             | {}               |
+| controller.tolerations    | Node taints to tolerate for the HPE CSI Driver controller Pods.                                    | []               |
+| controller.resources      | A resource block with requests and limits for controller containers.                               | From values.yaml |
+| csp.labels                | Additional labels for CSP Pods.                                                                    | {}               |
+| csp.nodeSelector          | Node labels for CSP Pods assignment.                                                               | {}               |
+| csp.affinity              | Affinity rules for the CSP Pods.                                                                   | {}               |
+| csp.tolerations           | Node taints to tolerate for the CSP Pods.                                                          | []               |
+| csp.resources             | A resource block with requests and limits for CSP containers.                                      | From values.yaml |
+| node.labels               | Additional labels for HPE CSI Driver node Pods.                                                    | {}               |
+| node.nodeSelector         | Node labels for HPE CSI Driver node Pods assignment.                                               | {}               |
+| node.affinity             | Affinity rules for the HPE CSI Driver node Pods.                                                   | {}               |
+| node.tolerations          | Node taints to tolerate for the HPE CSI Driver node Pods.                                          | []               |
+| node.resources            | A resource block with requests and limits for node containers.                                     | From values.yaml |
+| images                    | Key/value pairs of HPE CSI Driver runtime images.                                                  | From values.yaml |
 
 `*` = Disabling node conformance and configuration may prevent the CSI driver from functioning properly. See the [manual node configuration](https://scod.hpedev.io/csi_driver/operations.html#manual_node_configuration) section on SCOD to understand the consequences.
 

--- a/helm/charts/hpe-csi-driver/templates/pre-install-hook.yaml
+++ b/helm/charts/hpe-csi-driver/templates/pre-install-hook.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disablePreInstallHooks }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -25,3 +26,4 @@ spec:
             echo "Validating Secret..."
             {{ include "hpe-csi-storage.chapSecretValidation" . }}
             echo "Validation successful."
+{{- end }}

--- a/helm/charts/hpe-csi-driver/values.schema.json
+++ b/helm/charts/hpe-csi-driver/values.schema.json
@@ -15,6 +15,7 @@
             "disableNodeConformance": false,
             "disableNodeConfiguration": false,
             "disableHostDeletion": false,
+            "disablePreInstallHooks": false,
             "imagePullPolicy": "IfNotPresent",
             "iscsi": {
                 "chapSecretName": ""
@@ -135,6 +136,13 @@
             "$id": "#/properties/disableHostDeletion",
             "title": "Disable host deletion",
             "description": "Disables host deletion by the CSP when no volumes are associated with the host.",
+            "type": "boolean",
+            "default": false
+        },
+        "disablePreInstallHooks": {
+            "$id": "#/properties/disablePreInstallHooks",
+            "title": "Disable pre-install hooks",
+            "description": "Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems.",
             "type": "boolean",
             "default": false
         },

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -25,6 +25,9 @@ disableNodeMonitor: false
 # Disables host deletion by the CSP when no volumes are associated with the host
 disableHostDeletion: false
 
+# Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems
+disablePreInstallHooks: false
+
 # imagePullPolicy applied for all hpe-csi-driver images
 imagePullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
When using Argo CD the pre-install hook will cause a deadlock as Argo CD cannot use the `lookup` function from Helm (See https://github.com/argoproj/argo-cd/issues/4331).

This PR introduces a switch to disable the pre-install hook.