### PR TITLE
Max volumes per node and operator build fixes

### DIFF
--- a/helm/charts/hpe-csi-driver/README.md
+++ b/helm/charts/hpe-csi-driver/README.md
@@ -60,8 +60,10 @@ The following table lists the configurable parameters of the chart and their def
 | node.tolerations          | Node taints to tolerate for the HPE CSI Driver node Pods.                                          | []               |
 | node.resources            | A resource block with requests and limits for node containers.                                     | From values.yaml |
 | images                    | Key/value pairs of HPE CSI Driver runtime images.                                                  | From values.yaml |
+| maxVolumesPerNode         | Maximum number of volumes the CSI controller will publish to a node.`**`                           | 100 |
 
 `*` = Disabling node conformance and configuration may prevent the CSI driver from functioning properly. See the [manual node configuration](https://scod.hpedev.io/csi_driver/operations.html#manual_node_configuration) section on SCOD to understand the consequences.
+`**` = The default value is the current well tested upper limit. Do not increase the default value unless the use case has been well tested.
 
 It's recommended to create a [values.yaml](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver) file from the corresponding release of the chart and edit it to fit the environment the chart is being deployed to. Download and edit [a sample file](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver).
 

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -148,6 +148,10 @@ spec:
             - name: DISABLE_NODE_MONITOR
               value: "true"
             {{- end }}
+            {{ if .Values.maxVolumesPerNode -}}
+            - name: MAX_VOLUMES_PER_NODE
+              value: "{{ .Values.maxVolumesPerNode }}"
+            {{- end }}
             {{- if .Values.kubeletRootDir }}
             - name: KUBELET_ROOT_DIR
               value: {{ .Values.kubeletRootDir }}

--- a/helm/charts/hpe-csi-driver/values.schema.json
+++ b/helm/charts/hpe-csi-driver/values.schema.json
@@ -24,6 +24,7 @@
             "kubeletRootDir": "/var/lib/kubelet/",
             "disableNodeGetVolumeStats": false,
             "disableNodeMonitor": false,
+	    "maxVolumesPerNode": 100,
             "csp": {
                 "nodeSelector": {},
                 "tolerations": [],
@@ -58,6 +59,7 @@
         "kubeletRootDir",
         "disableNodeGetVolumeStats",
         "disableNodeMonitor",
+	"maxVolumesPerNode",
         "csp",
         "controller",
         "node",
@@ -203,6 +205,13 @@
             "type": "boolean",
             "default": false
         },
+	"maxVolumesPerNode": {
+            "$id": "#/properties/maxVolumesPerNode",
+            "title": "Max volumes per node",
+            "description": "The maximum amount of volumes the CSI controller will publish to a node.",
+            "type": "integer",
+            "default": 100
+	},
         "csp": {
             "nodeSelector": {
                 "$id": "#/properties/csp/properties/nodeSelector",

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -22,6 +22,9 @@ disableNodeGetVolumeStats: false
 # The Node Monitor ensure the node has no stale storage resources attached
 disableNodeMonitor: false
 
+# The number of volumes the CSI controller will publish to an individual node
+maxVolumesPerNode: 100
+
 # Disables host deletion by the CSP when no volumes are associated with the host
 disableHostDeletion: false
 

--- a/operators/hpe-csi-operator/Makefile
+++ b/operators/hpe-csi-operator/Makefile
@@ -9,6 +9,7 @@ COMMUNITY_OUTPUT=destinations/community-operators/current-version
 CERTIFIED_OUTPUT=destinations/certified-operators/current-version
 CERTIFIED_KUBE_PROXY=registry.redhat.io/openshift4/ose-kube-rbac-proxy:latest
 NAMESPACE ?= hpe-storage
+CHART ?= hpe-csi-driver
 VANITY_NAME ?= hpe-csi-operator
 IMAGE_NAME ?= csi-driver-operator
 BUNDLE_NAME ?= csi-driver-operator-bundle
@@ -37,10 +38,9 @@ init:
 		--group storage \
 		--version v1 \
 		--kind HPECSIDriver \
-		--project-name hpe-csi-operator \
-		--helm-chart hpe-csi-driver \
-		--helm-chart-repo https://hpe-storage.github.io/co-deployments \
-	        --helm-chart-version $(SOURCE_VERSION)
+		--project-name $(VANITY_NAME) \
+                --helm-chart ../../../docs/$(CHART)-$(VERSION).tgz \
+                --helm-chart-version $(SOURCE_VERSION)
 	touch init
 
 prep: init

--- a/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
+++ b/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
@@ -160,6 +160,16 @@ spec:
             path: disableNodeMonitor
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - displayName: Max volumes per node
+            description: "The maximum amount of volumes the CSI controller will publish to a node (default: 100)"
+            path: maxVolumesPerNode
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:number"
+          - displayName: Disable pre-install hooks
+            description: "Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems (default: false)"
+            path: disablePreInstallHooks
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
           - displayName: Disable Host deletion
             description: "Disables host deletion by the CSP when no volumes are associated with the host (default: false)"
             path: disableHostDeletion

--- a/operators/hpe-csi-operator/sources/hpecsidrivers.storage.hpe.com.crd.yaml
+++ b/operators/hpe-csi-operator/sources/hpecsidrivers.storage.hpe.com.crd.yaml
@@ -68,6 +68,12 @@ spec:
               disableNodeMonitor:
                 description: Disable the Node Monitor
                 type: boolean
+              maxVolumesPerNode:
+                description: Max volumes per node
+                type: integer
+              disablePreInstallHooks:
+                description: Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems
+                type: boolean
               disableHostDeletion:
                 description: Disables host deletion by the CSP when no volumes are associated with the host
                 type: boolean
@@ -1312,6 +1318,8 @@ spec:
             - disableNodeGetVolumeStats
             - disableNodeMonitor
             - disableHostDeletion
+            - maxVolumesPerNode
+            - disablePreInstallHooks
             - imagePullPolicy
             - images
             - iscsi


### PR DESCRIPTION
- Fix to allow testing of CON-3023/IDEA-542
- Added disablePreInstallHooks to Operator
- Changed operator build to use a local chart as source instead of being hardcoded to co-deployments. This allows testing of features simultaneously of the Helm chart and Operator build and submit a single PR.