### PR TITLE
Allow setting relabelings and metricRelabelings for hpe-array-exporter & hpe-csi-info-metrics

### DIFF
--- a/helm/charts/hpe-array-exporter/README.md
+++ b/helm/charts/hpe-array-exporter/README.md
@@ -25,6 +25,8 @@ The chart has these configurable parameters and default values.
 | service.labels | Labels to add to the Service, for example to include target labels in a ServiceMonitor scrape configuration. | `{}` |
 | service.annotations | Annotations to add to the Service, for example to configure it as a scrape target when using the Prometheus Helm chart's default configuration. | `{}` |
 | serviceMonitor.enable | Create a ServiceMonitor custom resource (used with the Prometheus Operator). | `false` |
+| serviceMonitor.relabelings | [Relabeling configuration](https://github.com/prometheus-operator/prometheus-operator/blob/c22d1da263ace4921586cbafc658418b5c8194ba/Documentation/api.md#relabelconfig) for exported metrics. | `[]` |
+| serviceMonitor.metricRelabelings | Metric [relabeling configuration](https://github.com/prometheus-operator/prometheus-operator/blob/c22d1da263ace4921586cbafc658418b5c8194ba/Documentation/api.md#relabelconfig) for exported metrics. | `[]` |
 | serviceMonitor.targetLabels | List of labels on the service to add to the scraped metric. | `[]` |
 
 The `arraySecret` parameter is required and has no default value.  A Secret used by the [HPE CSI Driver for Kubernetes](https://scod.hpedev.io/csi_driver/index.html) can be reused without modification.  Otherwise, use [this example](https://github.com/hpe-storage/co-deployments/blob/master/yaml/array-exporter/edge/hpe-array-exporter-secret.yaml) to create a new one.

--- a/helm/charts/hpe-array-exporter/templates/hpe-array-exporter.yaml
+++ b/helm/charts/hpe-array-exporter/templates/hpe-array-exporter.yaml
@@ -86,6 +86,8 @@ spec:
     app: {{ template "hpe-array-exporter.name" . }}
     release: {{ .Release.Name }}
 {{- if .Values.serviceMonitor.enable }}
+{{- $relabelings := .Values.serviceMonitor.relabelings | default list }}
+{{- $metricRelabelings := .Values.serviceMonitor.metricRelabelings | default list }}
 {{- $targetlabels := .Values.serviceMonitor.targetLabels | default list }}
 ---
 kind: ServiceMonitor
@@ -109,6 +111,14 @@ spec:
     - port: http-metrics
       scheme: http
       interval: 1m
+      {{- with $relabelings }}
+      relabelings:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with $metricRelabelings }}
+      metricRelabelings:
+{{ toYaml . | indent 8 }}
+      {{- end }}
   targetLabels:
     {{- with $targetlabels }}
 {{ toYaml . | indent 4 }}

--- a/helm/charts/hpe-array-exporter/values.schema.json
+++ b/helm/charts/hpe-array-exporter/values.schema.json
@@ -163,15 +163,31 @@
             "description": "Settings for the ServiceMonitor scraped by the Prometheus Operator.",
             "type": "object",
             "default": {
-		"enable": false,
-		"targetLabels": []
-	    },
+                "enable": false,
+                "relabelings": [],
+                "metricRelabelings": [],
+                "targetLabels": []
+            },
             "properties": {
                 "enable": {
                     "$id": "#/properties/serviceMonitor/properties/enable",
                     "title": "Enable ServiceMonitor for Array Exporter",
                     "description": "description",
                     "type": "boolean",
+                    "additionalProperties": true
+                },
+                "relabelings": {
+                    "$id": "#/properties/serviceMonitor/properties/relabelings",
+                    "title": "Relabelings",
+                    "desciption": "Relabeling configuration to be applied to metrics from this serviceMonitor (optional).",
+                    "type": "array",
+                    "additionalProperties": true
+                },
+                "metricRelabelings": {
+                    "$id": "#/properties/serviceMonitor/properties/metricRelabelings",
+                    "title": "Metric relabelings",
+                    "desciption": "Metric relabeling configuration to be applied to metrics from this serviceMonitor (optional).",
+                    "type": "array",
                     "additionalProperties": true
                 },
                 "targetLabels": {

--- a/helm/charts/hpe-array-exporter/values.yaml
+++ b/helm/charts/hpe-array-exporter/values.yaml
@@ -60,6 +60,17 @@ service:
 serviceMonitor:
   enable: false
 
+  # Prometheus relabel configurations. These are applied before scraping.
+  # References:
+  # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  # prometheus-operator/prometheus-operator/blob/c22d1da263ace4921586cbafc658418b5c8194ba/Documentation/api.md#relabelconfig
+  relabelings: []
+  # Prometheus metric relabel configurations. These are applied before ingestion.
+  # References:
+  # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+  # prometheus-operator/prometheus-operator/blob/c22d1da263ace4921586cbafc658418b5c8194ba/Documentation/api.md#relabelconfig
+  metricRelabelings: []
+
   # Corresponding labels on the Array Exporter service are added to
   # the scraped metrics
   targetLabels: []

--- a/helm/charts/hpe-csi-info-metrics/README.md
+++ b/helm/charts/hpe-csi-info-metrics/README.md
@@ -25,6 +25,8 @@ The chart has these configurable parameters and default values.
 | service.labels | Labels to add to the Service, for example to include target labels in a ServiceMonitor scrape configuration. | `{}` |
 | service.annotations | Annotations to add to the Service, for example to configure it as a scrape target when using the Prometheus Helm chart's default configuration. | `{}` |
 | serviceMonitor.enable | Create a ServiceMonitor custom resource (used with the Prometheus Operator). | `false` |
+| serviceMonitor.relabelings | [Relabeling configuration](https://github.com/prometheus-operator/prometheus-operator/blob/c22d1da263ace4921586cbafc658418b5c8194ba/Documentation/api.md#relabelconfig) for exported metrics. | `[]` |
+| serviceMonitor.metricRelabelings | Metric [relabeling configuration](https://github.com/prometheus-operator/prometheus-operator/blob/c22d1da263ace4921586cbafc658418b5c8194ba/Documentation/api.md#relabelconfig) for exported metrics. | `[]` |
 | serviceMonitor.targetLabels | List of labels on the service to add to the scraped metric. | `[]` |
 
 The `acceptEula` value must be set to `true`, confirming your acceptance of the [HPE End User License Agreement](https://www.hpe.com/us/en/software/licensing.html).

--- a/helm/charts/hpe-csi-info-metrics/templates/hpe-csi-info-metrics.yaml
+++ b/helm/charts/hpe-csi-info-metrics/templates/hpe-csi-info-metrics.yaml
@@ -107,6 +107,8 @@ spec:
   selector:
     app: hpe-csi-info-metrics
 {{- if .Values.serviceMonitor.enable }}
+{{- $relabelings := .Values.serviceMonitor.relabelings | default list }}
+{{- $metricRelabelings := .Values.serviceMonitor.metricRelabelings | default list }}
 {{- $targetlabels := .Values.serviceMonitor.targetLabels | default list }}
 ---
 kind: ServiceMonitor
@@ -129,6 +131,14 @@ spec:
     - port: http-metrics
       scheme: http
       interval: 1m
+      {{- with $relabelings }}
+      relabelings:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with $metricRelabelings }}
+      metricRelabelings:
+{{ toYaml . | indent 8 }}
+      {{- end }}
   targetLabels:
     {{- with $targetlabels }}
 {{ toYaml . | indent 4 }}

--- a/helm/charts/hpe-csi-info-metrics/values.schema.json
+++ b/helm/charts/hpe-csi-info-metrics/values.schema.json
@@ -3,7 +3,7 @@
     "$id": "http://example.com/example.json",
     "title": "HPE CSI Info Metrics Provider for Prometheus Helm Chart JSON Schema",
     "type": "object",
-    "default": 
+    "default":
         {
             "acceptEula": false,
             "image": {
@@ -153,15 +153,31 @@
             "description": "Settings for the ServiceMonitor scraped by the Prometheus Operator.",
             "type": "object",
             "default": {
-		"enable": false,
-		"targetLabels": []
-	    },
+                "enable": false,
+                "relabelings": [],
+                "metricRelabelings": [],
+                "targetLabels": []
+            },
             "properties": {
                 "enable": {
                     "$id": "#/properties/serviceMonitor/properties/enable",
                     "title": "Enable ServiceMonitor for CSI Info Metrics Provider",
                     "description": "description",
                     "type": "boolean",
+                    "additionalProperties": true
+                },
+                "relabelings": {
+                    "$id": "#/properties/serviceMonitor/properties/relabelings",
+                    "title": "Relabelings",
+                    "desciption": "Relabeling configuration to be applied to metrics from this serviceMonitor (optional).",
+                    "type": "array",
+                    "additionalProperties": true
+                },
+                "metricRelabelings": {
+                    "$id": "#/properties/serviceMonitor/properties/metricRelabelings",
+                    "title": "Metric relabelings",
+                    "desciption": "Metric relabeling configuration to be applied to metrics from this serviceMonitor (optional).",
+                    "type": "array",
                     "additionalProperties": true
                 },
                 "targetLabels": {

--- a/helm/charts/hpe-csi-info-metrics/values.yaml
+++ b/helm/charts/hpe-csi-info-metrics/values.yaml
@@ -55,6 +55,17 @@ service:
 serviceMonitor:
   enable: false
 
+  # Prometheus relabel configurations. These are applied before scraping.
+  # References:
+  # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  # prometheus-operator/prometheus-operator/blob/c22d1da263ace4921586cbafc658418b5c8194ba/Documentation/api.md#relabelconfig
+  relabelings: []
+  # Prometheus metric relabel configurations. These are applied before ingestion.
+  # References:
+  # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+  # prometheus-operator/prometheus-operator/blob/c22d1da263ace4921586cbafc658418b5c8194ba/Documentation/api.md#relabelconfig
+  metricRelabelings: []
+
   # Corresponding labels on the CSI Info Metrics Provider service are added to
   # the scraped metrics
   targetLabels: []


### PR DESCRIPTION
This PR allows setting `relabelings` and `metricRelabelings` on the `serviceMonitor` of the `hpe-array-exporter` and `hpe-csi-info-metrics` charts.

Here is an example usage, which makes the metric names consistent across all array types:
```yaml
serviceMonitor:
  metricRelabelings:
    - sourceLabels: [__name__]
      action: labelmap
      regex: "cpg|pool"
      replacement: "storagepool"
    - sourceLabels: [__name__]
      regex: "^hpe(primera|nimble|3par|alletra6000|alletra9000)_(.*)"
      targetLabel: "__name__"
      replacement: "hpe_$2"
    - sourceLabels: [__name__]
      regex: "^hpe_(pool|cpg)_(.*)"
      targetLabel: "__name__"
      replacement: "hpe_storagepool_$2"
```