### PR TITLE
AS-202640: Updating charts based on checks in chart-verifier tool

### DIFF
--- a/helm/charts/hpe-cosi-driver/Chart.yaml
+++ b/helm/charts/hpe-cosi-driver/Chart.yaml
@@ -5,8 +5,10 @@ description: A Helm chart for installing the HPE COSI Driver for Kubernetes
 type: application
 version: 1.0.1
 appVersion: "1.0.0"
+kubeVersion: ">=1.25.0 <=1.31.0"
 annotations:
   artifacthub.io/prerelease: "false"
+  charts.openshift.io/name: Red Hat build for HPE COSI Driver
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/category: storage

--- a/helm/charts/hpe-cosi-driver/Chart.yaml
+++ b/helm/charts/hpe-cosi-driver/Chart.yaml
@@ -5,10 +5,10 @@ description: A Helm chart for installing the HPE COSI Driver for Kubernetes
 type: application
 version: 1.0.1
 appVersion: "1.0.0"
-kubeVersion: ">=1.25.0 <=1.31.0"
+kubeVersion: ">=1.22.0 <=1.33.0"
 annotations:
   artifacthub.io/prerelease: "false"
-  charts.openshift.io/name: Red Hat build for HPE COSI Driver
+  charts.openshift.io/name: HPE COSI Driver for Kubernetes
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/license: Apache-2.0
   artifacthub.io/category: storage

--- a/helm/charts/hpe-cosi-driver/Chart.yaml
+++ b/helm/charts/hpe-cosi-driver/Chart.yaml
@@ -5,7 +5,7 @@ description: A Helm chart for installing the HPE COSI Driver for Kubernetes
 type: application
 version: 1.0.1
 appVersion: "1.0.0"
-kubeVersion: ">=1.22.0 <=1.33.0"
+kubeVersion: ">=1.25.0"
 annotations:
   artifacthub.io/prerelease: "false"
   charts.openshift.io/name: HPE COSI Driver for Kubernetes

--- a/helm/charts/hpe-cosi-driver/templates/tests/test-hpe-cosi-driver.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/tests/test-hpe-cosi-driver.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-deployment"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: hpe-cosi-driver
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: {{ .Values.containers.cosiDriver.name }}
+      image: busybox
+      imagePullPolicy: "IfNotPresent"
+      command: ['sh', '-c', 'echo test hook Pod has been run, nothing to test for now. && exit 0']
+  restartPolicy: Never

--- a/helm/charts/hpe-cosi-driver/templates/tests/test-hpe-cosi-driver.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/tests/test-hpe-cosi-driver.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: {{ .Values.containers.cosiDriver.name }}
-      image: busybox
+      image: {{ .Values.containers.cosiDriver.image }}
       imagePullPolicy: "IfNotPresent"
       command: ['sh', '-c', 'echo test hook Pod has been run, nothing to test for now. && exit 0']
   restartPolicy: Never


### PR DESCRIPTION
Verified COSI helm charts through chart-verifier tool (https://github.com/redhat-certification/chart-verifier) as a pre-requisite for Red Hat(OpenShift) certification.


1. Add a NOTES.txt for COSI chart (Non-Mandatory check)
2. Added a test file for COSI helm chart.
3. Added Openshift annotations & kube version under Chart.yaml

[chart-verifier-tool-results.txt](https://github.com/user-attachments/files/20010296/chart-verifier-tool-results.txt)

Continuing discussions from
https://github.com/hpe-storage/co-deployments/pull/418