### PR TITLE
Adding explicit securityContext settings to Helm Chart to support latest sidecar image

### DIFF
--- a/helm/charts/hpe-cosi-driver/templates/deployment.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         {{- include "hpe-cosi-driver.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.deployment.name }}-sa
+      securityContext:
+        fsGroup: 2000
+        runAsUser: 1000
+        runAsGroup: 1000
       volumes:
       - name: socket
         emptyDir: {}


### PR DESCRIPTION
Updating the Helm chart to support Kubernetes 1.24+ and the latest sidecar image. It adds explicit securityContext settings to run containers as non-root, and includes projected service account token handling to ensure proper API authentication, addressing changes in Kubernetes service account token management.
Reason for change : New Sidecar image fails with the current helm chart.