### PR TITLE
Successful completion of RH Preflight checks and updated the image digest from

### DIFF
--- a/operators/hpe-csi-operator/destinations/certified-operators/current-version/manifests/hpe-csi-operator.clusterserviceversion.yaml
+++ b/operators/hpe-csi-operator/destinations/certified-operators/current-version/manifests/hpe-csi-operator.clusterserviceversion.yaml
@@ -103,7 +103,7 @@ metadata:
     capabilities: Basic Install
     categories: Storage
     certified: "true"
-    containerImage: registry.connect.redhat.com/hpestorage/csi-driver-operator@sha256:cd779c5f2885b1d214338bf94186512a70359c7d509b88bc88a559025418c4d8
+    containerImage: registry.connect.redhat.com/hpestorage/csi-driver-operator@sha256:ecb39c7acdd7ef5fd8d583763d17c9d1c2ff17306c7f84429987edd58d9a1a01
     createdAt: "2025-07-28T10:05:13Z"
     description: A Container Storage Interface (CSI) driver for HPE storage platforms. The CSI driver allows you to use HPE storage with your preferred container orchestrator.
     features.operators.openshift.io/cnf: "false"
@@ -821,7 +821,7 @@ spec:
                       - --leader-elect
                       - --leader-election-id=hpe-csi-operator
                       - --health-probe-bind-address=:8081
-                    image: registry.connect.redhat.com/hpestorage/csi-driver-operator@sha256:cd779c5f2885b1d214338bf94186512a70359c7d509b88bc88a559025418c4d8
+                    image: registry.connect.redhat.com/hpestorage/csi-driver-operator@sha256:ecb39c7acdd7ef5fd8d583763d17c9d1c2ff17306c7f84429987edd58d9a1a01
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -915,8 +915,8 @@ spec:
       name: alletra-9000-primera-and-3par-csp-354bce7e1a771390d72a5160325c5e1d5386425b22512e40c6c74ec23efb3c07-annotation
     - image: registry.k8s.io/sig-storage/csi-provisioner@sha256:bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9
       name: csi-provisioner-bb057f866177d5f4139a1527e594499cbe0feeb67b63aaca8679dfdf0a6016f9-annotation
-    - image: registry.connect.redhat.com/hpestorage/csi-driver-operator@sha256:cd779c5f2885b1d214338bf94186512a70359c7d509b88bc88a559025418c4d8
-      name: csi-driver-operator-cd779c5f2885b1d214338bf94186512a70359c7d509b88bc88a559025418c4d8-annotation
+    - image: registry.connect.redhat.com/hpestorage/csi-driver-operator@sha256:ecb39c7acdd7ef5fd8d583763d17c9d1c2ff17306c7f84429987edd58d9a1a01
+      name: csi-driver-operator-ecb39c7acdd7ef5fd8d583763d17c9d1c2ff17306c7f84429987edd58d9a1a01-annotation
     - image: quay.io/hpestorage/volume-group-snapshotter@sha256:177d9abf8fbd3ac26ca4c12ca4b4adde20ebab308c79f10b04632f0171746fa8
       name: volume-group-snapshotter-177d9abf8fbd3ac26ca4c12ca4b4adde20ebab308c79f10b04632f0171746fa8-annotation
     - image: registry.k8s.io/sig-storage/csi-snapshotter@sha256:5f4bb469fec51147ce157329dab598c758da1b018bad6dad26f0ff469326d769
@@ -925,7 +925,7 @@ spec:
       name: csi-driver-fffd5a243dc0f7e1027f69754fce77e5df04cb0a71b808f22a3b3a09b392c676-annotation
     - image: registry.k8s.io/sig-storage/csi-attacher@sha256:5aaefc24f315b182233c8b6146077f8c32e274d864cb03c632206e78bd0302da
       name: csi-attacher-5aaefc24f315b182233c8b6146077f8c32e274d864cb03c632206e78bd0302da-annotation
-    - image: registry.connect.redhat.com/hpestorage/csi-driver-operator@sha256:cd779c5f2885b1d214338bf94186512a70359c7d509b88bc88a559025418c4d8
+    - image: registry.connect.redhat.com/hpestorage/csi-driver-operator@sha256:ecb39c7acdd7ef5fd8d583763d17c9d1c2ff17306c7f84429987edd58d9a1a01
       name: manager
     - image: quay.io/hpestorage/alletra-6000-and-nimble-csp@sha256:5480ffdebd74fdc547bc4a11b4434abac7bbfee3cee349f1ac893fbad84bb8d1
       name: alletra-6000-and-nimble-csp-5480ffdebd74fdc547bc4a11b4434abac7bbfee3cee349f1ac893fbad84bb8d1-annotation


### PR DESCRIPTION
https://catalog.redhat.com/software/containers/hpestorage/csi-driver-operator/5e501ff1ecb5246c09e8686f?container-tabs=gti&gti-tabs=registry-tokens&image=6889b779c93d827361c7caba