### PR TITLE
Pre-populate namespace

### DIFF
--- a/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
+++ b/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
@@ -14,6 +14,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
+    operatorframework.io/suggested-namespace: hpe-storage
     olm.skipRange: ">=1.0.0 <%SEMVER%"
     alm-examples: '[]'
     capabilities: Basic Install


### PR DESCRIPTION
This PR will pre-populate the `Namespace` selection for users deploying the Operator.

Like this:
<img width="575" height="243" alt="image" src="https://github.com/user-attachments/assets/6a15f9c7-7afa-4b12-9449-91bce4b19312" />
