### PR TITLE
Fix: Apply kubeletRootDir value to pods-mount-dir volumeMount

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -58,7 +58,11 @@ spec:
             - name: plugin-dir
               mountPath: /csi
             - name: pods-mount-dir
+              {{ if .Values.kubeletRootDir }}
+              mountPath: {{ .Values.kubeletRootDir }}
+              {{- else }}
               mountPath: /var/lib/kubelet
+              {{- end }}
             - name: log-dir
               mountPath: /var/log
           env:


### PR DESCRIPTION
# Fix: Apply kubeletRootDir value to pods-mount-dir volumeMount

Fixes path mismatch issues on MicroK8s and other distributions using custom kubelet paths.

Author: rsangunda <rsangunda@gmail.com>

## Problem

The `kubeletRootDir` parameter in `values.yaml` was not being applied to the `pods-mount-dir` volumeMount in the `hpe-csi-node-init` initContainer. The mountPath was hardcoded to `/var/lib/kubelet`, even when `kubeletRootDir` was set to a custom value.

This caused issues on distributions like MicroK8s where:
- The actual hostPath uses the custom kubelet path (e.g., `/var/snap/microk8s/common/var/lib/kubelet`)
- But the container tried to mount it at the hardcoded `/var/lib/kubelet`
- Leading to path mismatches and mount failures

## Error Example

```
MountVolume.MountDevice failed for volume "pvc-xxx": rpc error: code = Internal
desc = Failed to stage volume 062a200510ee339c26000000000000000000000456,
err: Error mounting device /dev/mapper/mpathu on mountpoint
/var/lib/kubelet/plugins/hpe.com/mounts/062a200510ee339c26000000000000000000000456
with options [], unable to mount the device at mountPoint:
/var/lib/kubelet/plugins/hpe.com/mounts/062a200510ee339c26000000000000000000000456.
Error: command mount failed with rc=32 err=mount:
/var/snap/microk8s/common/var/lib/kubelet/plugins/hpe.com/mounts/062a200510ee339c26000000000000000000000456:
/dev/mapper/mpathu already mounted on
/var/snap/microk8s/common/var/lib/kubelet/plugins/hpe.com/mounts/062a200510ee339c26000000000000000000000456.
```

## Solution

Added conditional logic to the `pods-mount-dir` volumeMount in the initContainer to respect the `kubeletRootDir` value:

```yaml
- name: pods-mount-dir
  {{ if .Values.kubeletRootDir }}
  mountPath: {{ .Values.kubeletRootDir }}
  {{- else }}
  mountPath: /var/lib/kubelet
  {{- end }}
```

This ensures the container mounts the volume at the correct path that matches the configured kubelet directory.

## Testing

- Tested on MicroK8s 1.31 with `kubeletRootDir: "/var/snap/microk8s/common/var/lib/kubelet"`
- CSI driver successfully mounts volumes without path mismatch errors
- Backward compatible - defaults to `/var/lib/kubelet` when `kubeletRootDir` is not set

## Impact

Enables HPE CSI Driver to work properly on MicroK8s and other Kubernetes distributions that use custom kubelet paths.