### PR TITLE
fix: replace invalid fragment-only $id in values.schema.json with val…

### DIFF
--- a/helm/charts/hpe-cosi-driver/values.schema.json
+++ b/helm/charts/hpe-cosi-driver/values.schema.json
@@ -77,7 +77,6 @@
       }
     },
     "resources": {
-      "$id": "resources",
       "type": "object",
       "title": "resource requests and limits",
       "additionalProperties": false,

--- a/helm/charts/hpe-cosi-driver/values.schema.json
+++ b/helm/charts/hpe-cosi-driver/values.schema.json
@@ -77,7 +77,7 @@
       }
     },
     "resources": {
-      "$id": "#/properties/resources",
+      "$id": "resources",
       "type": "object",
       "title": "resource requests and limits",
       "additionalProperties": false,


### PR DESCRIPTION
…id non-fragment URI (fixes #443)

- Root cause of issue https://github.com/hpe-storage/co-deployments/issues/443
- Here the , "$id": "#/properties/resources" (fragment-only URI) is invalid in JSON Schema Draft 2020-12
- Newer Helm versions enforce 2020-12 metaschema strictly
- The fix is to either remove this line completely or replace it with a valid non-fragment URI