### PR TITLE
Properly set default CSI attacher timeout

### DIFF
--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-controller.yaml
@@ -60,9 +60,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
-            {{- if and ( or (eq .Values.disable.primera false) (eq .Values.disable.alletra9000 false) ) ( or (eq .Values.disable.nimble true) (eq .Values.disable.alletra6000 true) ) }}
             - "--timeout=180s"
-            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
I was helping a user with a very peculiar problem that was traced back to the CSI attacher timing out and stacking requests on top of each other. 

This obscure templating stanza I've removed would force 3PAR CSP users to disable Nimble and Alletra6000 CSP to apply the correct timeout value for the 3PAR CSP. I'm not sure why it was decided to leave it as it was but the net result is that by default, the CSI attacher will timeout after just 15 seconds which is insanely low for a busy system and requests will pile up a mile high leaving exponential back-offs which yield prolonged workload startup times.

This is the error observed as reference: 

```
I0427 09:34:23.131053       1 connection.go:270] "GRPC response" driver="csi.hpe.com" VolumeAttachment="csi-a87f3ae3ea82d8affefec16f0fa7f0bc9b36893d81405371156037d04a1b8128" response="{}" err="rpc error: code = DeadlineExceeded desc = context deadline exceeded"
```