### PR TITLE
Updated Sidecar Version and Fixed Non Default Namespaces for COSI driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository contains the source declarations to deploy CO drivers (CSI and F
 - Deploy the [HPE GreenLake for File Storage CSI Driver](helm/charts/hpe-greenlake-file-csi-driver)
 - Deploy the [HPE Storage Array Exporter for Prometheus](helm/charts/hpe-array-exporter)
 - Deploy the [HPE CSI Info Metrics Provider for Prometheus](helm/charts/hpe-csi-info-metrics)
+- Deploy the [HPE COSI Driver for Kubernetes](helm/charts/hpe-cosi-driver)
+
 
 The HPE CSI Driver for Kubernetes Helm chart is also rendered on [ArtifactHub.io](https://artifacthub.io/packages/helm/hpe-storage/hpe-csi-driver).
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ We provide the [raw YAML files](yaml) to deploy the [HPE CSI Driver](https://git
 - YAML files for the [HPE CSI Driver for Kubernetes](yaml/csi-driver)
 - YAML files for the [HPE Storage Array Exporter for Prometheus](yaml/array-exporter)
 - YAML files for the [HPE CSI Info Metrics Provider for Prometheus](yaml/csi-info-metrics)
+- YAML files for the [HPE COSI Driver for Kubernetes](yaml/cosi-driver)
+
 
 How to perform an [advanced manual install](https://scod.hpedev.io/csi_driver/deployment.html#advanced_install) of the CSI driver.
 

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -30,7 +30,7 @@ The following parameters are supported by the Helm chart. During normal circumst
 | containers.cosiDriver.image | string | `"quay.io/hpestorage/cosi-driver:v1.0.0"` | Fully qualified registry path of cosiDriver |
 | containers.cosiDriver.imagePullPolicy | string | `"IfNotPresent"` | cosiDriver image pull policy |
 | containers.cosiDriver.name | string | `"hpe-cosi-driver"` | Name of the driver's container within the deployment |
-| containers.sideCar.image | string | `"registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.1"` | Fully qualified registry path of sideCar |
+| containers.sideCar.image | string | `"registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"` | Fully qualified registry path of sideCar |
 | containers.sideCar.imagePullPolicy | string | `"IfNotPresent"` | sideCar image pull policy |
 | containers.sideCar.name | string | `"hpe-cosi-provisioner-sidecar"` | Name of the driver's side car container within the deployment |
 | containers.sideCar.verbosityLevel | int | `5` | Specifies the verbosity of the logs that will be printed by the sidecar container |
@@ -45,17 +45,15 @@ Learn how to specify resource limits and requests in the official documentation 
 
 ## Installation Steps
 
-1. Create the custom resource definitions (CRDs) for the COSI driver API resources.
+1. Create the custom resource definitions (CRDs) for the COSI driver API resources and deploy the object storage controller
 
 ```
-kubectl apply -k github.com/kubernetes-sigs/container-object-storage-interface?ref=main
+kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface//?ref=release-0.2" \
+| sed -e "s/container-object-storage-system/default/g" \
+| kubectl apply -f -
 ```
 
-2. Deploy the object storage controller.
-
-```
-kubectl kustomize github.com/kubernetes-sigs/container-object-storage-interface/controller | sed 's/namespace: container-object-storage-system/namespace: default/' | kubectl apply -f -
-```
+Note: These commands assume installation in the default namespace, replace it if using a different one.
 
 
 **Note:** The SIG Storage resourcs are deployed in the "default" `Namespace` and the HPE COSI Driver needs to be deployed there as well. See [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more information.

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -53,7 +53,7 @@ kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface
 | kubectl apply -f -
 ```
 
-Note: Replace <namespace> with your custom namespace or default one as per the needs.
+Note: Replace with your custom namespace or default as per the need.
 
 
 **Note:** The SIG Storage resourcs are deployed in the "default" `Namespace` and the HPE COSI Driver needs to be deployed there as well. See [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more information.

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -49,11 +49,11 @@ Learn how to specify resource limits and requests in the official documentation 
 
 ```
 kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface//?ref=release-0.2" \
-| sed -e "s/container-object-storage-system/default/g" \
+| sed -e "s/container-object-storage-system/<namespace>/g" \
 | kubectl apply -f -
 ```
 
-Note: These commands assume installation in the default namespace, replace it if using a different one.
+Note: Replace <namespace> with your custom namespace or default one as per the needs.
 
 
 **Note:** The SIG Storage resourcs are deployed in the "default" `Namespace` and the HPE COSI Driver needs to be deployed there as well. See [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more information.

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -30,7 +30,7 @@ The following parameters are supported by the Helm chart. During normal circumst
 | containers.cosiDriver.image | string | `"quay.io/hpestorage/cosi-driver:v1.0.0"` | Fully qualified registry path of cosiDriver |
 | containers.cosiDriver.imagePullPolicy | string | `"IfNotPresent"` | cosiDriver image pull policy |
 | containers.cosiDriver.name | string | `"hpe-cosi-driver"` | Name of the driver's container within the deployment |
-| containers.sideCar.image | string | `"registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"` | Fully qualified registry path of sideCar |
+| containers.sideCar.image | string | `"registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"` | Fully qualified registry path of sidecar |
 | containers.sideCar.imagePullPolicy | string | `"IfNotPresent"` | sideCar image pull policy |
 | containers.sideCar.name | string | `"hpe-cosi-provisioner-sidecar"` | Name of the driver's side car container within the deployment |
 | containers.sideCar.verbosityLevel | int | `5` | Specifies the verbosity of the logs that will be printed by the sidecar container |
@@ -53,8 +53,7 @@ kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface
 | kubectl apply -f -
 ```
 
-Note: Replace with your custom namespace or default as per the need.
-
+**Note:** Replace `<namespace>` with the installation Namespace.
 
 **Note:** The SIG Storage resourcs are deployed in the "default" `Namespace` and the HPE COSI Driver needs to be deployed there as well. See [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more information.
 

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -30,13 +30,12 @@ The following parameters are supported by the Helm chart. During normal circumst
 | containers.cosiDriver.image | string | `"quay.io/hpestorage/cosi-driver:v1.0.0"` | Fully qualified registry path of cosiDriver |
 | containers.cosiDriver.imagePullPolicy | string | `"IfNotPresent"` | cosiDriver image pull policy |
 | containers.cosiDriver.name | string | `"hpe-cosi-driver"` | Name of the driver's container within the deployment |
-| containers.sideCar.image | string | `"registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"` | Fully qualified registry path of sidecar |
+| containers.sideCar.image | string | `"registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"` | Fully qualified registry path of sideCar |
 | containers.sideCar.imagePullPolicy | string | `"IfNotPresent"` | sideCar image pull policy |
 | containers.sideCar.name | string | `"hpe-cosi-provisioner-sidecar"` | Name of the driver's side car container within the deployment |
 | containers.sideCar.verbosityLevel | int | `5` | Specifies the verbosity of the logs that will be printed by the sidecar container |
 | deployment.name | string | `"hpe-cosi-provisioner"` | The name of the driver's Kubernetes deployment |
 | fullnameOverride | string | `"hpe-cosi-driver"` | Name of deployment |
-| namespace | string | `"default"` | Namespace must remain default |
 | podEvictionToleration | int | `300` | Pod Toleration time in seconds |
 | regSecretName | string | `""` | Secret that contains the private image registry credentials to pull the cosiDriver image |
 | resources | object | `{}` | Resources such as CPU limits, Memory limits, CPU request and Memory request applied to the COSI driver and the COSI sidecar individually. |

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -54,7 +54,7 @@ kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface
 
 **Note:** Replace `<namespace>` with the installation Namespace.
 
-**Note:** The SIG Storage resources can be deployed in any `Namespace`, and the HPE COSI driver can also be deployed in any namespace. Refer to the [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more details.
+**Note:** The SIG Storage resources can be deployed in any "namespace", and the HPE COSI Driver can also be deployed in any namespace. Refer to the [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more details.
 3. Installing the chart.
 
 To install the chart with the name "my-hpe-cosi-driver", follow this example.

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -30,7 +30,7 @@ The following parameters are supported by the Helm chart. During normal circumst
 | containers.cosiDriver.image | string | `"quay.io/hpestorage/cosi-driver:v1.0.0"` | Fully qualified registry path of cosiDriver |
 | containers.cosiDriver.imagePullPolicy | string | `"IfNotPresent"` | cosiDriver image pull policy |
 | containers.cosiDriver.name | string | `"hpe-cosi-driver"` | Name of the driver's container within the deployment |
-| containers.sideCar.image | string | `"registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"` | Fully qualified registry path of sideCar |
+| containers.sideCar.image | string | `"registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"` | Fully qualified registry path of sidecar |
 | containers.sideCar.imagePullPolicy | string | `"IfNotPresent"` | sideCar image pull policy |
 | containers.sideCar.name | string | `"hpe-cosi-provisioner-sidecar"` | Name of the driver's side car container within the deployment |
 | containers.sideCar.verbosityLevel | int | `5` | Specifies the verbosity of the logs that will be printed by the sidecar container |
@@ -44,7 +44,7 @@ Learn how to specify resource limits and requests in the official documentation 
 
 ## Installation Steps
 
-1. Create the custom resource definitions (CRDs) for the COSI driver API resources and deploy the object storage controller
+1. Create the custom resource definitions (CRDs) for the COSI driver API resources and deploy the object storage controller.
 
 ```
 kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface//?ref=release-0.2" \
@@ -54,8 +54,7 @@ kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface
 
 **Note:** Replace `<namespace>` with the installation Namespace.
 
-**Note:** The SIG Storage resourcs are deployed in the "default" `Namespace` and the HPE COSI Driver needs to be deployed there as well. See [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more information.
-
+**Note:** The SIG Storage resources can be deployed in any `Namespace`, and the HPE COSI driver can also be deployed in any namespace. Refer to the [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more details.
 3. Installing the chart.
 
 To install the chart with the name "my-hpe-cosi-driver", follow this example.

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -28,17 +28,15 @@ Learn how to specify resource limits and requests in the official documentation 
 
 ## Installation Steps
 
-1. Create the custom resource definitions (CRDs) for the COSI driver API resources.
+1. Create the custom resource definitions (CRDs) for the COSI driver API resources and deploy the object storage controller
 
 ```
-kubectl apply -k github.com/kubernetes-sigs/container-object-storage-interface-api
+kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface//?ref=release-0.2" \
+| sed -e "s/container-object-storage-system/<namespace>/g" \
+| kubectl apply -f -
 ```
 
-2. Deploy the object storage controller.
-
-```
-kubectl apply -k github.com/kubernetes-sigs/container-object-storage-interface-controller
-```
+**Note:** Replace `<namespace>` with the installation Namespace.
 
 **Note:** The SIG Storage resourcs are deployed in the "default" `Namespace` and the HPE COSI Driver needs to be deployed there as well. See [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more information.
 

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -38,7 +38,7 @@ kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface
 
 **Note:** Replace `<namespace>` with the installation Namespace.
 
-**Note:** The SIG Storage resources can be deployed in any `Namespace`, and the HPE COSI driver can also be deployed in any namespace. Refer to the [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more details.
+**Note:** The SIG Storage resources can be deployed in any "namespace", and the HPE COSI Driver can also be deployed in any namespace. Refer to the [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more details.
 3. Installing the chart.
 
 To install the chart with the name "my-hpe-cosi-driver", follow this example.

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -28,7 +28,7 @@ Learn how to specify resource limits and requests in the official documentation 
 
 ## Installation Steps
 
-1. Create the custom resource definitions (CRDs) for the COSI driver API resources and deploy the object storage controller
+1. Create the custom resource definitions (CRDs) for the COSI driver API resources and deploy the object storage controller.
 
 ```
 kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface//?ref=release-0.2" \
@@ -38,8 +38,7 @@ kubectl kustomize "github.com/kubernetes-sigs/container-object-storage-interface
 
 **Note:** Replace `<namespace>` with the installation Namespace.
 
-**Note:** The SIG Storage resourcs are deployed in the "default" `Namespace` and the HPE COSI Driver needs to be deployed there as well. See [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more information.
-
+**Note:** The SIG Storage resources can be deployed in any `Namespace`, and the HPE COSI driver can also be deployed in any namespace. Refer to the [known limitations](https://scod.hpedev.io/cosi_driver/index.html#known_limitations) for more details.
 3. Installing the chart.
 
 To install the chart with the name "my-hpe-cosi-driver", follow this example.

--- a/helm/charts/hpe-cosi-driver/templates/deployment.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.deployment.name }}
-  namespace: {{ .Values.Namespace }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "hpe-cosi-driver.labels" . | nindent 4 }}
 spec:

--- a/helm/charts/hpe-cosi-driver/templates/deployment.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/deployment.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.deployment.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "hpe-cosi-driver.labels" . | nindent 4 }}
 spec:

--- a/helm/charts/hpe-cosi-driver/templates/rbac.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/rbac.yaml
@@ -33,7 +33,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.deployment.name }}-sa
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ .Values.deployment.name }}-role

--- a/helm/charts/hpe-cosi-driver/templates/serviceaccount.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/serviceaccount.yaml
@@ -4,6 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.deployment.name }}-sa
-  namespace: {{ .Values.Namespace }}
+  namespace: {{ .Values.namespace }}
   labels:
     {{- include "hpe-cosi-driver.labels" . | nindent 4 }}

--- a/helm/charts/hpe-cosi-driver/templates/serviceaccount.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/serviceaccount.yaml
@@ -4,6 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.deployment.name }}-sa
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "hpe-cosi-driver.labels" . | nindent 4 }}

--- a/helm/charts/hpe-cosi-driver/values.schema.json
+++ b/helm/charts/hpe-cosi-driver/values.schema.json
@@ -15,7 +15,7 @@
     },
     "namespace": {
       "type": "string",
-      "pattern": "^(default)$"
+      "maxLength": 253
     },
     "deployment": {
       "type": "object",

--- a/helm/charts/hpe-cosi-driver/values.schema.json
+++ b/helm/charts/hpe-cosi-driver/values.schema.json
@@ -14,8 +14,7 @@
       "maxLength": 128
     },
     "namespace": {
-      "type": "string",
-      "maxLength": 253
+      "type": "string"
     },
     "deployment": {
       "type": "object",

--- a/helm/charts/hpe-cosi-driver/values.schema.json
+++ b/helm/charts/hpe-cosi-driver/values.schema.json
@@ -13,9 +13,6 @@
       "type": "string",
       "maxLength": 128
     },
-    "namespace": {
-      "type": "string"
-    },
     "deployment": {
       "type": "object",
       "additionalProperties": true,

--- a/helm/charts/hpe-cosi-driver/values.yaml
+++ b/helm/charts/hpe-cosi-driver/values.yaml
@@ -5,7 +5,7 @@
 # fullnameOverride -- Name of deployment
 fullnameOverride: "hpe-cosi-driver"
 componentName: "container-object-storage-interface"
-# namespace -- Namespace must remain default
+# namespace -- Namespace where the COSI driver will be installed. Must already exist.
 namespace: default
 
 # deployment name of the provisioner
@@ -28,7 +28,7 @@ containers:
     # containers.sideCar.name -- Name of the driver's side car container within the deployment
     name: "hpe-cosi-provisioner-sidecar"
     # containers.sideCar.image -- Fully qualified registry path of sideCar
-    image: "registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.1"
+    image: "registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"
     # containers.sideCar.imagePullPolicy -- sideCar image pull policy
     imagePullPolicy: IfNotPresent
     # Verbosity level: Small postive integer values are generally recommended.

--- a/helm/charts/hpe-cosi-driver/values.yaml
+++ b/helm/charts/hpe-cosi-driver/values.yaml
@@ -5,8 +5,6 @@
 # fullnameOverride -- Name of deployment
 fullnameOverride: "hpe-cosi-driver"
 componentName: "container-object-storage-interface"
-# namespace -- Namespace where the COSI driver will be installed. Must already exist.
-namespace: default
 
 # deployment name of the provisioner
 deployment:

--- a/helm/charts/hpe-cosi-driver/values.yaml
+++ b/helm/charts/hpe-cosi-driver/values.yaml
@@ -25,7 +25,7 @@ containers:
   sideCar:
     # containers.sideCar.name -- Name of the driver's side car container within the deployment
     name: "hpe-cosi-provisioner-sidecar"
-    # containers.sideCar.image -- Fully qualified registry path of sideCar
+    # containers.sideCar.image -- Fully qualified registry path of sidecar
     image: "registry.k8s.io/sig-storage/objectstorage-sidecar:v0.2.2"
     # containers.sideCar.imagePullPolicy -- sideCar image pull policy
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
The sidecar version has been updated to v0.2.2 in COSI driver.
Fixed namespace templating in the Helm chart so the driver can be installed into any namespace, not just default one.

(Please note the changes made here are with respect to COSI)