### PR TITLE
Moving dynamic app version from selector labels to common

### DIFF
--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -37,6 +37,9 @@ The following parameters are supported by the Helm chart. During normal circumst
 | deployment.name | string | `"hpe-cosi-provisioner"` | The name of the driver's Kubernetes deployment |
 | fullnameOverride | string | `"hpe-cosi-driver"` | Name of deployment |
 | podEvictionToleration | int | `300` | Pod Toleration time in seconds |
+| preUpgradeHook | object | `{"enabled":true,"image":"quay.io/hpestorage/cosi-driver:v1.0.0"}` | Configuration for the pre-upgrade hook that handles immutable selector field changes |
+| preUpgradeHook.enabled | bool | `true` | Enable the pre-upgrade hook to delete deployment before upgrade |
+| preUpgradeHook.image | string | `"quay.io/hpestorage/cosi-driver:v1.0.0"` | Image used for the pre-upgrade hook job (must have /bin/sh and wget or curl) Uses the COSI driver image by default |
 | regSecretName | string | `""` | Secret that contains the private image registry credentials to pull the cosiDriver image |
 | resources | object | `{}` | Resources such as CPU limits, Memory limits, CPU request and Memory request applied to the COSI driver and the COSI sidecar individually. |
 
@@ -80,22 +83,45 @@ kubectl -n default get pods -w
 
 ## Upgrading from v1.x to v2.x
 
-Due to a change in the Deployment's `spec.selector.matchLabels` between chart versions 1.x and 2.x, a direct `helm upgrade` will fail with:
+The chart includes a **pre-upgrade hook** that automatically handles the Deployment selector label changes between v1.x and v2.x. Simply run:
 
 ```
-spec.selector: Invalid value: ... field is immutable
+helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
 ```
 
-Kubernetes does not allow modification of a Deployment's selector after creation. To upgrade, delete the existing Deployment first:
+The hook deletes the existing Deployment before the upgrade, allowing Helm to recreate it with the corrected selector labels. Existing `BucketClaim` and `BucketAccess` resources are not affected.
+
+**Note:** There will be a brief period of unavailability for the COSI provisioner during the upgrade until the new Pod is running.
+
+### Pre-upgrade Hook Configuration
+
+The hook requires an image with `/bin/sh` and either `wget` or `curl`. By default, it uses the COSI driver image.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
+| `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
+
+To use an alternative image (e.g., if your registry doesn't have the COSI image):
+
+```
+helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
+  --set preUpgradeHook.image=curlimages/curl:8.7.1
+```
+
+To disable the hook and manually delete the Deployment:
+
+```
+helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
+  --set preUpgradeHook.enabled=false
+```
+
+If the hook is disabled, you must manually delete the Deployment before upgrading:
 
 ```
 kubectl delete deployment hpe-cosi-provisioner -n <namespace>
 helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
 ```
-
-Helm will recreate the Deployment with the corrected selector labels. Existing `BucketClaim` and `BucketAccess` resources are not affected.
-
-**Note:** There will be a brief period of unavailability for the COSI provisioner during the upgrade until the new Pod is running.
 
 ## Using
 

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -102,7 +102,7 @@ The hook requires an image with `/bin/sh` and either `wget` or `curl`. By defaul
 | `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
 | `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
 
-To disable the hook and manually delete the Deployment:
+**Note:** To disable the hook and manually delete the Deployment:
 
 ```
 helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -37,8 +37,7 @@ The following parameters are supported by the Helm chart. During normal circumst
 | deployment.name | string | `"hpe-cosi-provisioner"` | The name of the driver's Kubernetes deployment |
 | fullnameOverride | string | `"hpe-cosi-driver"` | Name of deployment |
 | podEvictionToleration | int | `300` | Pod Toleration time in seconds |
-| preUpgradeHook | object | `{"enabled":true}` | Configuration for the pre-upgrade hook that handles immutable selector field changes |
-| preUpgradeHook.enabled | bool | `true` | Enable the pre-upgrade hook to delete deployment before upgrade |
+| preUpgradeHookEnabled | bool | `true` | Enable the pre-upgrade hook to delete deployment before upgrade |
 | regSecretName | string | `""` | Secret that contains the private image registry credentials to pull the cosiDriver image |
 | resources | object | `{}` | Resources such as CPU limits, Memory limits, CPU request and Memory request applied to the COSI driver and the COSI sidecar individually. |
 
@@ -78,40 +77,6 @@ Monitor the deployment of the COSI driver `Pods`:
 
 ```
 kubectl -n default get pods -w
-```
-
-## Upgrading from v1.x to v2.x
-
-The chart includes a **pre-upgrade hook** that automatically handles the Deployment selector label changes between v1.x and v2.x. Simply run:
-
-```
-helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
-```
-
-The hook deletes the existing Deployment before the upgrade, allowing Helm to recreate it with the corrected selector labels. Existing `BucketClaim` and `BucketAccess` resources are not affected.
-
-**Note:** There will be a brief period of unavailability for the COSI provisioner during the upgrade until the new Pod is running.
-
-### Pre-upgrade Hook Configuration
-
-The hook re-uses the COSI driver image (`containers.cosiDriver.image`) which includes `/bin/sh` and `wget`.
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
-
-To disable the hook and manually delete the Deployment:
-
-```
-helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
-  --set preUpgradeHook.enabled=false
-```
-
-**Note:** If the hook is disabled, you must manually delete the Deployment before upgrading:
-
-```
-kubectl delete deployment hpe-cosi-provisioner -n <namespace>
-helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
 ```
 
 ## Using

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -102,13 +102,6 @@ The hook requires an image with `/bin/sh` and either `wget` or `curl`. By defaul
 | `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
 | `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
 
-To use an alternative image (e.g., if your registry doesn't have the COSI image):
-
-```
-helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
-  --set preUpgradeHook.image=curlimages/curl:8.7.1
-```
-
 To disable the hook and manually delete the Deployment:
 
 ```

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -78,6 +78,25 @@ Monitor the deployment of the COSI driver `Pods`:
 kubectl -n default get pods -w
 ```
 
+## Upgrading from v1.x to v2.x
+
+Due to a change in the Deployment's `spec.selector.matchLabels` between chart versions 1.x and 2.x, a direct `helm upgrade` will fail with:
+
+```
+spec.selector: Invalid value: ... field is immutable
+```
+
+Kubernetes does not allow modification of a Deployment's selector after creation. To upgrade, delete the existing Deployment first:
+
+```
+kubectl delete deployment hpe-cosi-provisioner -n <namespace>
+helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
+```
+
+Helm will recreate the Deployment with the corrected selector labels. Existing `BucketClaim` and `BucketAccess` resources are not affected.
+
+**Note:** There will be a brief period of unavailability for the COSI provisioner during the upgrade until the new Pod is running.
+
 ## Using
 
 Refer to the [HPE COSI Driver for Kubernetes](https://scod.hpedev.io/cosi_driver/deployment.html#add_an_hpe_storage_backend) documentation on SCOD. Also, it's helpful to be familiar with [object storage management](https://kubernetes.io/blog/2022/09/02/cosi-kubernetes-object-storage-management/) in Kubernetes prior to deploying workloads utilizing object storage.

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -37,9 +37,8 @@ The following parameters are supported by the Helm chart. During normal circumst
 | deployment.name | string | `"hpe-cosi-provisioner"` | The name of the driver's Kubernetes deployment |
 | fullnameOverride | string | `"hpe-cosi-driver"` | Name of deployment |
 | podEvictionToleration | int | `300` | Pod Toleration time in seconds |
-| preUpgradeHook | object | `{"enabled":true,"image":"quay.io/hpestorage/cosi-driver:v1.0.0"}` | Configuration for the pre-upgrade hook that handles immutable selector field changes |
+| preUpgradeHook | object | `{"enabled":true}` | Configuration for the pre-upgrade hook that handles immutable selector field changes |
 | preUpgradeHook.enabled | bool | `true` | Enable the pre-upgrade hook to delete deployment before upgrade |
-| preUpgradeHook.image | string | `"quay.io/hpestorage/cosi-driver:v1.0.0"` | Image used for the pre-upgrade hook job (must have /bin/sh and wget or curl) Uses the COSI driver image by default |
 | regSecretName | string | `""` | Secret that contains the private image registry credentials to pull the cosiDriver image |
 | resources | object | `{}` | Resources such as CPU limits, Memory limits, CPU request and Memory request applied to the COSI driver and the COSI sidecar individually. |
 
@@ -95,12 +94,11 @@ The hook deletes the existing Deployment before the upgrade, allowing Helm to re
 
 ### Pre-upgrade Hook Configuration
 
-The hook requires an image with `/bin/sh` and either `wget` or `curl`. By default, it uses the COSI driver image.
+The hook re-uses the COSI driver image (`containers.cosiDriver.image`) which includes `/bin/sh` and `wget`.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
-| `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
 
 To disable the hook and manually delete the Deployment:
 

--- a/helm/charts/hpe-cosi-driver/README.md
+++ b/helm/charts/hpe-cosi-driver/README.md
@@ -102,14 +102,14 @@ The hook requires an image with `/bin/sh` and either `wget` or `curl`. By defaul
 | `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
 | `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
 
-**Note:** To disable the hook and manually delete the Deployment:
+To disable the hook and manually delete the Deployment:
 
 ```
 helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
   --set preUpgradeHook.enabled=false
 ```
 
-If the hook is disabled, you must manually delete the Deployment before upgrading:
+**Note:** If the hook is disabled, you must manually delete the Deployment before upgrading:
 
 ```
 kubectl delete deployment hpe-cosi-provisioner -n <namespace>

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -83,13 +83,6 @@ The hook requires an image with `/bin/sh` and either `wget` or `curl`. By defaul
 | `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
 | `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
 
-To use an alternative image (e.g., if your registry doesn't have the COSI image):
-
-```
-helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
-  --set preUpgradeHook.image=curlimages/curl:8.7.1
-```
-
 To disable the hook and manually delete the Deployment:
 
 ```

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -83,14 +83,14 @@ The hook requires an image with `/bin/sh` and either `wget` or `curl`. By defaul
 | `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
 | `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
 
-**Note:** To disable the hook and manually delete the Deployment:
+To disable the hook and manually delete the Deployment:
 
 ```
 helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
   --set preUpgradeHook.enabled=false
 ```
 
-If the hook is disabled, you must manually delete the Deployment before upgrading:
+**Note:** If the hook is disabled, you must manually delete the Deployment before upgrading:
 
 ```
 kubectl delete deployment hpe-cosi-provisioner -n <namespace>

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -83,7 +83,7 @@ The hook requires an image with `/bin/sh` and either `wget` or `curl`. By defaul
 | `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
 | `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
 
-To disable the hook and manually delete the Deployment:
+**Note:** To disable the hook and manually delete the Deployment:
 
 ```
 helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -76,12 +76,11 @@ The hook deletes the existing Deployment before the upgrade, allowing Helm to re
 
 ### Pre-upgrade Hook Configuration
 
-The hook requires an image with `/bin/sh` and either `wget` or `curl`. By default, it uses the COSI driver image.
+The hook re-uses the COSI driver image (`containers.cosiDriver.image`) which includes `/bin/sh` and `wget`.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
-| `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
 
 To disable the hook and manually delete the Deployment:
 

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -62,6 +62,25 @@ Monitor the deployment of the COSI driver `Pods`:
 kubectl -n default get pods -w
 ```
 
+## Upgrading from v1.x to v2.x
+
+Due to a change in the Deployment's `spec.selector.matchLabels` between chart versions 1.x and 2.x, a direct `helm upgrade` will fail with:
+
+```
+spec.selector: Invalid value: ... field is immutable
+```
+
+Kubernetes does not allow modification of a Deployment's selector after creation. To upgrade, delete the existing Deployment first:
+
+```
+kubectl delete deployment hpe-cosi-provisioner -n <namespace>
+helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
+```
+
+Helm will recreate the Deployment with the corrected selector labels. Existing `BucketClaim` and `BucketAccess` resources are not affected.
+
+**Note:** There will be a brief period of unavailability for the COSI provisioner during the upgrade until the new Pod is running.
+
 ## Using
 
 Refer to the [HPE COSI Driver for Kubernetes](https://scod.hpedev.io/cosi_driver/deployment.html#add_an_hpe_storage_backend) documentation on SCOD. Also, it's helpful to be familiar with [object storage management](https://kubernetes.io/blog/2022/09/02/cosi-kubernetes-object-storage-management/) in Kubernetes prior to deploying workloads utilizing object storage.

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -64,22 +64,45 @@ kubectl -n default get pods -w
 
 ## Upgrading from v1.x to v2.x
 
-Due to a change in the Deployment's `spec.selector.matchLabels` between chart versions 1.x and 2.x, a direct `helm upgrade` will fail with:
+The chart includes a **pre-upgrade hook** that automatically handles the Deployment selector label changes between v1.x and v2.x. Simply run:
 
 ```
-spec.selector: Invalid value: ... field is immutable
+helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
 ```
 
-Kubernetes does not allow modification of a Deployment's selector after creation. To upgrade, delete the existing Deployment first:
+The hook deletes the existing Deployment before the upgrade, allowing Helm to recreate it with the corrected selector labels. Existing `BucketClaim` and `BucketAccess` resources are not affected.
+
+**Note:** There will be a brief period of unavailability for the COSI provisioner during the upgrade until the new Pod is running.
+
+### Pre-upgrade Hook Configuration
+
+The hook requires an image with `/bin/sh` and either `wget` or `curl`. By default, it uses the COSI driver image.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
+| `preUpgradeHook.image` | `quay.io/hpestorage/cosi-driver:v2.0.0` | Image used for the hook job |
+
+To use an alternative image (e.g., if your registry doesn't have the COSI image):
+
+```
+helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
+  --set preUpgradeHook.image=curlimages/curl:8.7.1
+```
+
+To disable the hook and manually delete the Deployment:
+
+```
+helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
+  --set preUpgradeHook.enabled=false
+```
+
+If the hook is disabled, you must manually delete the Deployment before upgrading:
 
 ```
 kubectl delete deployment hpe-cosi-provisioner -n <namespace>
 helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
 ```
-
-Helm will recreate the Deployment with the corrected selector labels. Existing `BucketClaim` and `BucketAccess` resources are not affected.
-
-**Note:** There will be a brief period of unavailability for the COSI provisioner during the upgrade until the new Pod is running.
 
 ## Using
 

--- a/helm/charts/hpe-cosi-driver/README.md.gotmpl
+++ b/helm/charts/hpe-cosi-driver/README.md.gotmpl
@@ -62,40 +62,6 @@ Monitor the deployment of the COSI driver `Pods`:
 kubectl -n default get pods -w
 ```
 
-## Upgrading from v1.x to v2.x
-
-The chart includes a **pre-upgrade hook** that automatically handles the Deployment selector label changes between v1.x and v2.x. Simply run:
-
-```
-helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
-```
-
-The hook deletes the existing Deployment before the upgrade, allowing Helm to recreate it with the corrected selector labels. Existing `BucketClaim` and `BucketAccess` resources are not affected.
-
-**Note:** There will be a brief period of unavailability for the COSI provisioner during the upgrade until the new Pod is running.
-
-### Pre-upgrade Hook Configuration
-
-The hook re-uses the COSI driver image (`containers.cosiDriver.image`) which includes `/bin/sh` and `wget`.
-
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `preUpgradeHook.enabled` | `true` | Enable/disable the pre-upgrade hook |
-
-To disable the hook and manually delete the Deployment:
-
-```
-helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace> \
-  --set preUpgradeHook.enabled=false
-```
-
-**Note:** If the hook is disabled, you must manually delete the Deployment before upgrading:
-
-```
-kubectl delete deployment hpe-cosi-provisioner -n <namespace>
-helm upgrade <release-name> hpe-storage/hpe-cosi-driver -n <namespace>
-```
-
 ## Using
 
 Refer to the [HPE COSI Driver for Kubernetes](https://scod.hpedev.io/cosi_driver/deployment.html#add_an_hpe_storage_backend) documentation on SCOD. Also, it's helpful to be familiar with [object storage management](https://kubernetes.io/blog/2022/09/02/cosi-kubernetes-object-storage-management/) in Kubernetes prior to deploying workloads utilizing object storage.

--- a/helm/charts/hpe-cosi-driver/templates/_helpers.tpl
+++ b/helm/charts/hpe-cosi-driver/templates/_helpers.tpl
@@ -38,6 +38,9 @@ Common labels
 {{- define "hpe-cosi-driver.labels" -}}
 helm.sh/chart: {{ include "hpe-cosi-driver.chart" . }}
 {{ include "hpe-cosi-driver.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -46,9 +49,6 @@ Selector labels
 */}}
 {{- define "hpe-cosi-driver.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "hpe-cosi-driver.name" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/part-of: {{ .Values.componentName | quote }}
 {{- end }}

--- a/helm/charts/hpe-cosi-driver/templates/pre-upgrade-hook.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/pre-upgrade-hook.yaml
@@ -74,7 +74,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: pre-upgrade
-          image: {{ .Values.preUpgradeHook.image }}
+          image: {{ .Values.containers.cosiDriver.image }}
           command:
             - /bin/sh
             - -c

--- a/helm/charts/hpe-cosi-driver/templates/pre-upgrade-hook.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/pre-upgrade-hook.yaml
@@ -1,7 +1,7 @@
 # © Copyright Hewlett Packard Enterprise Development LP
 # Pre-upgrade hook to delete the deployment before upgrade
 # This prevents "spec.selector: field is immutable" errors
-{{- if .Values.preUpgradeHook.enabled }}
+{{- if .Values.preUpgradeHookEnabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/charts/hpe-cosi-driver/templates/pre-upgrade-hook.yaml
+++ b/helm/charts/hpe-cosi-driver/templates/pre-upgrade-hook.yaml
@@ -1,0 +1,116 @@
+# © Copyright Hewlett Packard Enterprise Development LP
+# Pre-upgrade hook to delete the deployment before upgrade
+# This prevents "spec.selector: field is immutable" errors
+{{- if .Values.preUpgradeHook.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.deployment.name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hpe-cosi-driver.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.deployment.name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hpe-cosi-driver.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.deployment.name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hpe-cosi-driver.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.deployment.name }}-pre-upgrade
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Values.deployment.name }}-pre-upgrade
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.deployment.name }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hpe-cosi-driver.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 60
+  template:
+    metadata:
+      name: {{ .Values.deployment.name }}-pre-upgrade
+      labels:
+        {{- include "hpe-cosi-driver.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Values.deployment.name }}-pre-upgrade
+      restartPolicy: Never
+      containers:
+        - name: pre-upgrade
+          image: {{ .Values.preUpgradeHook.image }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              APISERVER="https://kubernetes.default.svc"
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CACERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              NAMESPACE="{{ .Release.Namespace }}"
+              DEPLOYMENT="{{ .Values.deployment.name }}"
+              
+              # Function to make HTTP request (tries wget first, then curl)
+              http_request() {
+                METHOD=$1
+                URL=$2
+                if command -v wget > /dev/null 2>&1; then
+                  wget -q --ca-certificate=${CACERT} \
+                    --header="Authorization: Bearer ${TOKEN}" \
+                    --method=${METHOD} \
+                    -O - "${URL}" 2>/dev/null
+                elif command -v curl > /dev/null 2>&1; then
+                  curl -s --cacert ${CACERT} \
+                    -H "Authorization: Bearer ${TOKEN}" \
+                    -X ${METHOD} "${URL}"
+                else
+                  echo "ERROR: Neither wget nor curl found in image"
+                  exit 1
+                fi
+              }
+              
+              echo "Checking for existing deployment ${DEPLOYMENT}..."
+              if http_request GET "${APISERVER}/apis/apps/v1/namespaces/${NAMESPACE}/deployments/${DEPLOYMENT}" > /dev/null 2>&1; then
+                echo "Deleting deployment ${DEPLOYMENT} to handle immutable selector fields..."
+                http_request DELETE "${APISERVER}/apis/apps/v1/namespaces/${NAMESPACE}/deployments/${DEPLOYMENT}"
+                echo "Deployment deleted successfully"
+              else
+                echo "Deployment ${DEPLOYMENT} not found, skipping deletion"
+              fi
+{{- end }}

--- a/helm/charts/hpe-cosi-driver/values.yaml
+++ b/helm/charts/hpe-cosi-driver/values.yaml
@@ -19,7 +19,7 @@ containers:
     # containers.cosiDriver.name -- Name of the driver's container within the deployment
     name: "hpe-cosi-driver"
     # containers.cosiDriver.image --  Fully qualified registry path of cosiDriver
-    image: &cosiImage "quay.io/hpestorage/cosi-driver:v1.0.0"
+    image: "quay.io/hpestorage/cosi-driver:v1.0.0"
     # containers.cosiDriver.imagePullPolicy -- cosiDriver image pull policy
     imagePullPolicy: IfNotPresent
   sideCar:
@@ -60,6 +60,3 @@ podEvictionToleration: 300
 preUpgradeHook:
   # preUpgradeHook.enabled -- Enable the pre-upgrade hook to delete deployment before upgrade
   enabled: true
-  # preUpgradeHook.image -- Image used for the pre-upgrade hook job (must have /bin/sh and wget or curl)
-  # Uses the COSI driver image by default
-  image: *cosiImage

--- a/helm/charts/hpe-cosi-driver/values.yaml
+++ b/helm/charts/hpe-cosi-driver/values.yaml
@@ -19,7 +19,7 @@ containers:
     # containers.cosiDriver.name -- Name of the driver's container within the deployment
     name: "hpe-cosi-driver"
     # containers.cosiDriver.image --  Fully qualified registry path of cosiDriver
-    image: "quay.io/hpestorage/cosi-driver:v1.0.0"
+    image: &cosiImage "quay.io/hpestorage/cosi-driver:v1.0.0"
     # containers.cosiDriver.imagePullPolicy -- cosiDriver image pull policy
     imagePullPolicy: IfNotPresent
   sideCar:
@@ -55,3 +55,11 @@ resources: {}
   #   memory: 128Mi
 # podEvictionToleration -- Pod Toleration time in seconds
 podEvictionToleration: 300
+
+# preUpgradeHook -- Configuration for the pre-upgrade hook that handles immutable selector field changes
+preUpgradeHook:
+  # preUpgradeHook.enabled -- Enable the pre-upgrade hook to delete deployment before upgrade
+  enabled: true
+  # preUpgradeHook.image -- Image used for the pre-upgrade hook job (must have /bin/sh and wget or curl)
+  # Uses the COSI driver image by default
+  image: *cosiImage

--- a/helm/charts/hpe-cosi-driver/values.yaml
+++ b/helm/charts/hpe-cosi-driver/values.yaml
@@ -56,7 +56,5 @@ resources: {}
 # podEvictionToleration -- Pod Toleration time in seconds
 podEvictionToleration: 300
 
-# preUpgradeHook -- Configuration for the pre-upgrade hook that handles immutable selector field changes
-preUpgradeHook:
-  # preUpgradeHook.enabled -- Enable the pre-upgrade hook to delete deployment before upgrade
-  enabled: true
+# preUpgradeHookEnabled -- Enable the pre-upgrade hook to delete deployment before upgrade
+preUpgradeHookEnabled: true


### PR DESCRIPTION
Problem:
1. The hpe-cosi-driver.selectorLabels template in _helpers.tpl includes app.kubernetes.io/version: .Chart.AppVersion as a selector label. 
2. This label is used in spec.selector.matchLabels of the Deployment resource.
3. When upgrading from chart v1.0.1 (appVersion 1.0.0) to chart v2.0.0 (appVersion 2.0.0), the rendered selector changes:
`# v1.0.1 selector
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: hpe-cosi-driver
      app.kubernetes.io/version: "1.0.0"    <-- changes on upgrade
      app.kubernetes.io/instance: <release>
      app.kubernetes.io/part-of: "container-object-storage-interface"`
4. Kubernetes forbids mutation of spec.selector on an existing Deployment, causing the upgrade to fail with:
`spec.selector: field is immutable`

Fix:

1. Move app.kubernetes.io/version out of selectorLabels (which feeds matchLabels) and into the labels template only (which feeds metadata.labels). 
2. Version is inherently mutable and should never be part of an immutable selector.
3. Added pre-upgrade hook to handle existing installations with old selector labels