### PR TITLE
Allow disconnected install decorator and additional fixes

### DIFF
--- a/operators/hpe-csi-operator/Makefile
+++ b/operators/hpe-csi-operator/Makefile
@@ -48,8 +48,7 @@ init:
 		--version v1 \
 		--kind HPECSIDriver \
 		--project-name $(VANITY_NAME) \
-                --helm-chart ../../../docs/$(CHART)-$(VERSION).tgz \
-                --helm-chart-version $(SOURCE_VERSION)
+                --helm-chart ../../../docs/$(CHART)-$(SOURCE_VERSION).tgz \
 
         # Build & push our base Helm Operator with latest UBI images
 	git clone https://github.com/operator-framework/operator-sdk
@@ -74,6 +73,10 @@ prep: init
 	# Fix memory on the manager.
 	sed -i.remove -e "s/memory: 128Mi/memory: 1Gi/g" $(IMAGE_NAME)/config/manager/manager.yaml && \
 		rm -f $(IMAGE_NAME)/config/manager/manager.yaml.remove
+
+        # Restrict manager to only watch installed Namespace
+	yq -i '.spec.template.spec.containers[0].env += [{"name": "WATCH_NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}}]' \
+		$(IMAGE_NAME)/config/manager/manager.yaml
 	
 	# Dockerfile for operator
 	sed -e "s|%FROM%|FROM $(OPERATOR_SDK_URL)|" sources/operator.Dockerfile > $(IMAGE_NAME)/Dockerfile

--- a/operators/hpe-csi-operator/README.md
+++ b/operators/hpe-csi-operator/README.md
@@ -39,7 +39,7 @@ o------------------------o           o-----------------------o
 
 ## Testing and building for OLM
 
-Install the `operator-sdk` binary on your computer, `docker`, `docker-buildx`, `make` and `sed` is also needed.
+Install the `operator-sdk` binary on your computer, `docker`, `docker-buildx`, `yq`, `make` and `sed` is also needed.
 
 On you cluster, install OLM (ensure your KUBECONFIG points to a cluster).
 

--- a/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
+++ b/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
   annotations:
     features.operators.openshift.io/csi: "true"
-    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"

--- a/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
+++ b/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
@@ -362,7 +362,7 @@ spec:
   installModes:
   - supported: true
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace


### PR DESCRIPTION
This PR fixes the following issues:
- A user reported issues with `oc-mirror`. Research proved that the annotation is merely a decorator for the ecosystem catalog. We should have the annotation as the operator can be mirrored offline as we provide all images in `.spec.relatedImages` that is required by `oc-mirror` to function. The user's issue was related to missing flags to `oc-mirror`.
- The Operator SDK supplied manager allows the `HPECSIDriver` resource to be created outside its deployed `Namespace` by anyone with the "edit" permission role. This is a security concern and the manager will now only monitor the `Namespace` where the Operator was installed into by an admin.
- An issue with the Makefile prevented creating custom operator build tags from an existing chart.