### PR TITLE
Operator defaults, bump Operator SDK and remove broken "replaces: "

### DIFF
--- a/operators/hpe-csi-operator/Makefile
+++ b/operators/hpe-csi-operator/Makefile
@@ -48,7 +48,7 @@ init:
 		--version v1 \
 		--kind HPECSIDriver \
 		--project-name $(VANITY_NAME) \
-                --helm-chart ../../../docs/$(CHART)-$(SOURCE_VERSION).tgz \
+                --helm-chart ../../../docs/$(CHART)-$(SOURCE_VERSION).tgz
 
         # Build & push our base Helm Operator with latest UBI images
 	git clone https://github.com/operator-framework/operator-sdk

--- a/operators/hpe-csi-operator/Makefile
+++ b/operators/hpe-csi-operator/Makefile
@@ -3,7 +3,7 @@ VERSION ?= 0.0.0
 SOURCE_VERSION ?= $(VERSION)
 REPO_NAME ?= quay.io/myrepo
 # Do not use < 1.38.0
-OPERATOR_SDK_TAG = v1.42.2
+OPERATOR_SDK_TAG = v1.42.3
 OPERATOR_SDK = 'operator-sdk version: "$(OPERATOR_SDK_TAG)"'
 
 # Don't set these, preferably

--- a/operators/hpe-csi-operator/Makefile
+++ b/operators/hpe-csi-operator/Makefile
@@ -157,9 +157,6 @@ certified: prep
 	# Create certified-operators content
 	rm -rf $(CERTIFIED_OUTPUT)/*
 	cp -f -a $(IMAGE_NAME)/bundle/* $(CERTIFIED_OUTPUT)
-	sed -i.remove -e "s|$(REPO_NAME)/$(IMAGE_NAME)|$(RH_REPO_NAME)/$(IMAGE_NAME)|g" -e "/replaces: /d" \
-		$(CERTIFIED_OUTPUT)/manifests/hpe-csi-operator.clusterserviceversion.yaml && \
-		rm -f $(CERTIFIED_OUTPUT)/manifests/hpe-csi-operator.clusterserviceversion.yaml.remove
 
 	# Rename certified display name
 	sed -i.remove -e "s/$(COMMUNITY_DISPLAY_NAME)/$(CERTIFIED_DISPLAY_NAME)/g" \

--- a/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
+++ b/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
@@ -30,7 +30,6 @@ metadata:
     operatorhub.io/ui-metadata-max-k8s-version: "1.36"
 spec:
   minKubeVersion: 1.32.0
-  replaces: hpe-csi-operator.v3.1.0
   # <<< for each new release
   apiservicedefinitions: {}
   install:

--- a/operators/hpe-csi-operator/sources/hpecsidrivers.storage.hpe.com.crd.yaml
+++ b/operators/hpe-csi-operator/sources/hpecsidrivers.storage.hpe.com.crd.yaml
@@ -1323,23 +1323,7 @@ spec:
                         type: object
                     type: object
                 type: object
-            required:
-            - disable
-            - disableNodeConformance
-            - disableNodeConfiguration
-            - disableNodeGetVolumeStats
-            - disableNodeMonitor
-            - disableHostDeletion
-            - maxVolumesPerNode
-            - disablePreInstallHooks
-            - imagePullPolicy
-            - images
-            - iscsi
-            - kubeletRootDir
-            - logLevel
-            - csp
-            - controller
-            - node
+            required: []
             type: object
           status:
             description: HpecsidriverStatus defines the observed state of HPECSIDriver


### PR DESCRIPTION
This PR removes the need to supplying a full list of defaults when creating a `HPECSIDriver` resource.

```
oc create -f-
apiVersion: storage.hpe.com/v1
kind: HPECSIDriver
metadata:
  name: hpecsidriver-sample
spec: {}
CTRL^D
```

Before:
```
The HPECSIDriver "hpecsidriver-sample" is invalid:
* spec.disable: Required value
* spec.disableNodeConformance: Required value
* spec.disableNodeConfiguration: Required value
* spec.disableNodeGetVolumeStats: Required value
* spec.disableNodeMonitor: Required value
* spec.disableHostDeletion: Required value
* spec.maxVolumesPerNode: Required value
* spec.disablePreInstallHooks: Required value
* spec.imagePullPolicy: Required value
* spec.images: Required value
* spec.iscsi: Required value
* spec.kubeletRootDir: Required value
* spec.logLevel: Required value
* spec.csp: Required value
* spec.controller: Required value
* spec.node: Required value
```

After:
```
hpecsidriver.storage.hpe.com/hpecsidriver-sample created
```

The defaults are now picked from the Helm chart defaults as they should.

Also removed some lint from the `Makefile` and bumped `operator-sdk`.

Removed the broken "replaces" directive that doesn't work and we're note currently using.