### PR TITLE
Add disableHostname/maxHostNameLen options for arrays with hostname length limits

### DIFF
--- a/helm/charts/hpe-csi-driver/README.md
+++ b/helm/charts/hpe-csi-driver/README.md
@@ -44,6 +44,8 @@ The following table lists the configurable parameters of the chart and their def
 | disableNodeMonitor        | Disables the Node Monitor that manages stale storage resources.                                    | false            |
 | disableHostDeletion       | Disables host deletion by the CSP when no volumes are associated with the host.                    | false            |
 | disablePreInstallHooks    | Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems. | false            |
+| disableHostname           | Set to `true` to generate a unique hash for storage backends that have hostname length limitations. | false           |
+| maxHostnameLength         | Max hostname length accepted by the storage backend when `disableHostname` is true.                | 31               |
 | imagePullPolicy           | Image pull policy (`Always`, `IfNotPresent`, `Never`).                                             | IfNotPresent     |
 | iscsi.chapSecretName      | Secret containing chapUser and chapPassword for iSCSI                                              | ""               |
 | logLevel                  | Log level. Can be one of `info`, `debug`, `trace`, `warn` and `error`.                             | info             |

--- a/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
+++ b/helm/charts/hpe-csi-driver/templates/hpe-csi-node.yaml
@@ -166,6 +166,14 @@ spec:
             - name: DISABLE_NODE_GET_VOLUMESTATS
               value: "true"
             {{- end }}
+            {{- if .Values.disableHostname }}
+            - name: DISABLE_HOSTNAME
+              value: "true"
+            {{- end }}
+            {{- if and .Values.disableHostname .Values.maxHostnameLength }}
+            - name: MAX_HOSTNAME_LEN
+              value: "{{ .Values.maxHostnameLength }}"
+            {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           securityContext:
             privileged: true

--- a/helm/charts/hpe-csi-driver/values.schema.json
+++ b/helm/charts/hpe-csi-driver/values.schema.json
@@ -18,6 +18,8 @@
             "disableNodeConfiguration": false,
             "disableHostDeletion": false,
             "disablePreInstallHooks": false,
+            "disableHostname": false,
+            "maxHostnameLength": 31,
             "imagePullPolicy": "IfNotPresent",
             "iscsi": {
                 "chapSecretName": ""
@@ -61,6 +63,8 @@
         "kubeletRootDir",
         "disableNodeGetVolumeStats",
         "disableNodeMonitor",
+        "disableHostname",
+        "maxHostnameLength",
 	"maxVolumesPerNode",
         "csp",
         "controller",
@@ -165,6 +169,20 @@
             "description": "Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems.",
             "type": "boolean",
             "default": false
+        },
+        "disableHostname": {
+            "$id": "#/properties/disableHostname",
+            "title": "Disable hostname",
+            "description": "Set to true to generate a unique hash for storage backends that have hostname length limitations.",
+            "type": "boolean",
+            "default": false
+        },
+        "maxHostnameLength": {
+            "$id": "#/properties/maxHostnameLength",
+            "title": "Max hostname length",
+            "description": "Max hostname length accepted by the storage backend when disableHostname is true.",
+            "type": "integer",
+            "default": 31
         },
         "imagePullPolicy": {
             "$id": "#/properties/imagePullPolicy",

--- a/helm/charts/hpe-csi-driver/values.yaml
+++ b/helm/charts/hpe-csi-driver/values.yaml
@@ -33,6 +33,12 @@ disableHostDeletion: false
 # Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems
 disablePreInstallHooks: false
 
+# Set to true to generate a unique hash for storage backends that have hostname length limitations
+disableHostname: false
+
+# Max hostname length accepted by the storage backend when disableHostname is true
+maxHostnameLength: 31
+
 # imagePullPolicy applied for all hpe-csi-driver images
 imagePullPolicy: "IfNotPresent"
 

--- a/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
+++ b/operators/hpe-csi-operator/sources/hpe-csi-operator.csv.yaml
@@ -185,6 +185,16 @@ spec:
             path: disableHostDeletion
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - displayName: Disable Hostname
+            description: "Set to true to generate a unique hash for storage backends that have hostname length limitations (default: false)"
+            path: disableHostname
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - displayName: Max hostname length
+            description: "Max hostname length accepted by the storage backend when Disable Hostname is true (default: 31)"
+            path: maxHostnameLength
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:number"
           - displayName: iSCSI Configuration
             description: "Configuration for iSCSI CHAP authenticaton"
             path: iscsi

--- a/operators/hpe-csi-operator/sources/hpecsidrivers.storage.hpe.com.crd.yaml
+++ b/operators/hpe-csi-operator/sources/hpecsidrivers.storage.hpe.com.crd.yaml
@@ -83,6 +83,12 @@ spec:
               disableHostDeletion:
                 description: Disables host deletion by the CSP when no volumes are associated with the host
                 type: boolean
+              disableHostname:
+                description: Set to true to generate a unique hash for storage backends that have hostname length limitations
+                type: boolean
+              maxHostnameLength:
+                description: Max hostname length accepted by the storage backend when disableHostname is true
+                type: integer
               imagePullPolicy:
                 description: Image Pull Policy for HPE CSI driver images
                 type: string


### PR DESCRIPTION
## Summary

Companion chart/operator change for hpe-storage/csi-driver#561, which adds an opt-in `DISABLE_HOSTNAME` env var (with a configurable `MAX_HOSTNAME_LEN`, default 27) so node hostnames that exceed a storage backend's naming limit get replaced with a short `csi-<hash>` identifier instead of failing host registration outright.

## Changes

- `helm/charts/hpe-csi-driver`: add `disableHostname` (default `false`) and `maxHostNameLen` (default `27`) values, wired into the `hpe-csi-driver` node container env as `DISABLE_HOSTNAME`/`MAX_HOSTNAME_LEN`, following the same pattern as `disableNodeGetVolumeStats`/`disableHostDeletion`. Updated `values.schema.json` and the README configuration table to match.
- `operators/hpe-csi-operator/sources`: expose both fields on the `HPECSIDriver` CRD and CSV descriptors, following the same pattern as `disableHostDeletion`.

## Test plan

- [x] `helm lint` / `helm template` on the modified chart, confirming `DISABLE_HOSTNAME`/`MAX_HOSTNAME_LEN` only render when set
- [x] Live-tested via `helm upgrade` against a real OpenShift + HPE Primera cluster (release `hpecsidriver-sample`) running a patched csi-driver image: with `disableHostname=true` and `maxHostNameLen` set to both `25` and `27`, host registration and volume publish/mount succeeded end-to-end for fresh PVCs at each length, confirming the value flows from Helm values through to the running driver correctly (not hardcoded)